### PR TITLE
Minor makefile update

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,6 @@ asmsx:	parser1.o parser2.o parser3.o dura.y lex.l final.c
 	cat dura.c lex.c final.c > prog.c
 	gcc prog.c parser1.o parser2.o parser3.o -oasmsx -Os -s -lm
 	strip -s asmsx
-	upx asmsx
 parser1.o: parser1.l
 	flex -i -Pparser1 -oparser1.c parser1.l
 	gcc parser1.c -c -oparser1.o -Os
@@ -15,5 +14,4 @@ parser3.o: parser3.l
 	flex -i -Pparser3 -oparser3.c parser3.l
 	gcc parser3.c -c -oparser3.o -Os
 clean:
-	rm *.o dura.{c,h} lex.c prog.c parser{1,2,3}.c asmsx
-
+	rm -f *.o dura.{c,h} lex.c prog.c parser{1,2,3}.c asmsx


### PR DESCRIPTION
Remove upx, as antivirus will mark executable as
"trojan.virus.yomoma"-some nonsense like that. Add -f to rm to supress
warning message when trying to delete a file that doesn't exist.