### PR TITLE
Fix multiple GCC compilation warnings and update makefile

### DIFF
--- a/src/dura.y
+++ b/src/dura.y
@@ -1066,53 +1066,53 @@ void hacer_error(int codigo)
  printf("%s, line %d: ",strtok(fuente,"\042"),lineas);
  switch (codigo)
  {
-  case 0: printf("syntax error\n");break;
-  case 1: printf("memory overflow\n");break;
-  case 2: printf("wrong register combination\n");break;
-  case 3: printf("wrong interruption mode\n");break;
-  case 4: printf("destiny register should be A\n");break;
-  case 5: printf("source register should be A\n");break;
-  case 6: printf("value should be 0\n");break;
-  case 7: printf("missing condition\n");break;
-  case 8: printf("unreachable address\n");break;
-  case 9: printf("wrong condition\n");break;
-  case 10: printf("wrong restart address\n");break;
-  case 11: printf("symbol table overflow\n");break;
-  case 12: printf("undefined identifier\n");break;
-  case 13: printf("undefined local label\n");break;
-  case 14: printf("symbol redefinition\n");break;
-  case 15: printf("size redefinition\n");break;
-  case 16: printf("reserved word used as identifier\n");break;
-  case 17: printf("code size overflow\n");break;
-  case 18: printf("binary file not found\n");break;
-  case 19: printf("ROM directive should preceed any code\n");break;
-  case 20: printf("type previously defined\n");break;
-  case 21: printf("BASIC directive should preceed any code\n");break;
-  case 22: printf("page out of range\n");break;
-  case 23: printf("MSXDOS directive should preceed any code\n");break;
-  case 24: printf("no code in the whole file\n");break;
-  case 25: printf("only available for MSXDOS\n");break;
-  case 26: printf("machine not defined\n");break;
-  case 27: printf("MegaROM directive should preceed any code\n");break;
-  case 28: printf("cannot write ROM code/data to page 3\n");break;
-  case 29: printf("included binary shorter than expected\n");break;
-  case 30: printf("wrong number of bytes to skip/include\n");break;
-  case 31: printf("megaROM subpage overflow\n");break;
-  case 32: printf("subpage 0 can only be defined by megaROM directive\n");break;
-  case 33: printf("unsupported mapper type\n");break;
-  case 34: printf("megaROM code should be between 4000h and BFFFh\n");break;
-  case 35: printf("code/data without subpage\n");break;
-  case 36: printf("megaROM mapper subpage out of range\n");break;
-  case 37: printf("megaROM subpage already defined\n");break;
-  case 38: printf("Konami megaROM forces page 0 at 4000h\n");break;
-  case 39: printf("megaROM subpage not defined\n");break;
-  case 40: printf("megaROM-only macro used\n");break;
-  case 41: printf("only for ROMs and megaROMs\n");break;
-  case 42: printf("ELSE without IF\n");break;
-  case 43: printf("ENDIF without IF\n");break;
-  case 44: printf("Cannot nest more IF's\n");break;
-  case 45: printf("IF not closed\n");break;
-  case 46: printf("Sinclair directive should preceed any code\n");break;
+  case 0: fprintf(stderr, "syntax error\n");break;
+  case 1: fprintf(stderr, "memory overflow\n");break;
+  case 2: fprintf(stderr, "wrong register combination\n");break;
+  case 3: fprintf(stderr, "wrong interruption mode\n");break;
+  case 4: fprintf(stderr, "destiny register should be A\n");break;
+  case 5: fprintf(stderr, "source register should be A\n");break;
+  case 6: fprintf(stderr, "value should be 0\n");break;
+  case 7: fprintf(stderr, "missing condition\n");break;
+  case 8: fprintf(stderr, "unreachable address\n");break;
+  case 9: fprintf(stderr, "wrong condition\n");break;
+  case 10: fprintf(stderr, "wrong restart address\n");break;
+  case 11: fprintf(stderr, "symbol table overflow\n");break;
+  case 12: fprintf(stderr, "undefined identifier\n");break;
+  case 13: fprintf(stderr, "undefined local label\n");break;
+  case 14: fprintf(stderr, "symbol redefinition\n");break;
+  case 15: fprintf(stderr, "size redefinition\n");break;
+  case 16: fprintf(stderr, "reserved word used as identifier\n");break;
+  case 17: fprintf(stderr, "code size overflow\n");break;
+  case 18: fprintf(stderr, "binary file not found\n");break;
+  case 19: fprintf(stderr, "ROM directive should preceed any code\n");break;
+  case 20: fprintf(stderr, "type previously defined\n");break;
+  case 21: fprintf(stderr, "BASIC directive should preceed any code\n");break;
+  case 22: fprintf(stderr, "page out of range\n");break;
+  case 23: fprintf(stderr, "MSXDOS directive should preceed any code\n");break;
+  case 24: fprintf(stderr, "no code in the whole file\n");break;
+  case 25: fprintf(stderr, "only available for MSXDOS\n");break;
+  case 26: fprintf(stderr, "machine not defined\n");break;
+  case 27: fprintf(stderr, "MegaROM directive should preceed any code\n");break;
+  case 28: fprintf(stderr, "cannot write ROM code/data to page 3\n");break;
+  case 29: fprintf(stderr, "included binary shorter than expected\n");break;
+  case 30: fprintf(stderr, "wrong number of bytes to skip/include\n");break;
+  case 31: fprintf(stderr, "megaROM subpage overflow\n");break;
+  case 32: fprintf(stderr, "subpage 0 can only be defined by megaROM directive\n");break;
+  case 33: fprintf(stderr, "unsupported mapper type\n");break;
+  case 34: fprintf(stderr, "megaROM code should be between 4000h and BFFFh\n");break;
+  case 35: fprintf(stderr, "code/data without subpage\n");break;
+  case 36: fprintf(stderr, "megaROM mapper subpage out of range\n");break;
+  case 37: fprintf(stderr, "megaROM subpage already defined\n");break;
+  case 38: fprintf(stderr, "Konami megaROM forces page 0 at 4000h\n");break;
+  case 39: fprintf(stderr, "megaROM subpage not defined\n");break;
+  case 40: fprintf(stderr, "megaROM-only macro used\n");break;
+  case 41: fprintf(stderr, "only for ROMs and megaROMs\n");break;
+  case 42: fprintf(stderr, "ELSE without IF\n");break;
+  case 43: fprintf(stderr, "ENDIF without IF\n");break;
+  case 44: fprintf(stderr, "Cannot nest more IF's\n");break;
+  case 45: fprintf(stderr, "IF not closed\n");break;
+  case 46: fprintf(stderr, "Sinclair directive should preceed any code\n");break;
  }
 
  remove("~tmppre.?");
@@ -1126,13 +1126,13 @@ void hacer_advertencia(int codigo)
  printf("%s, line %d: Warning: ",strtok(fuente,"\042"),lineas);
  switch (codigo)
  {
-  case 0: printf("undefined error\n");break;
-  case 1: printf("16-bit overflow\n");break;
-  case 2: printf("8-bit overflow\n");break;
-  case 3: printf("3-bit overflow\n");break;
-  case 4: printf("output cannot be converted to CAS\n");break;
-  case 5: printf("non official Zilog syntax\n");break;
-  case 6: printf("undocumented Zilog instruction\n");break;
+  case 0: fprintf(stderr, "undefined error\n");break;
+  case 1: fprintf(stderr, "16-bit overflow\n");break;
+  case 2: fprintf(stderr, "8-bit overflow\n");break;
+  case 3: fprintf(stderr, "3-bit overflow\n");break;
+  case 4: fprintf(stderr, "output cannot be converted to CAS\n");break;
+  case 5: fprintf(stderr, "non official Zilog syntax\n");break;
+  case 6: fprintf(stderr, "undocumented Zilog instruction\n");break;
  }
  advertencias++;
  }
@@ -1434,7 +1434,7 @@ void guardar_binario()
    for (i=1,j=0;i<=lastpage;i++) j+=usedpage[i];
    j>>=1;
    if (j<lastpage)
-     printf("Warning: %i out of %i megaROM pages are not defined\n",lastpage-j,lastpage);
+     fprintf(stderr, "Warning: %i out of %i megaROM pages are not defined\n",lastpage-j,lastpage);
   }
 
   printf("Binary file %s saved\n",binario);
@@ -1555,8 +1555,8 @@ void finalizar()
  if (cassette&2) generar_wav();
  if (maxima>0) salvar_simbolos();
  printf("Completed in %.2f seconds",(float)clock()/(float)CLOCKS_PER_SEC);
- if (advertencias>1) printf(", %i warnings\n",advertencias);
-  else if (advertencias==1) printf(", 1 warning\n");
+ if (advertencias>1) fprintf(stderr, ", %i warnings\n",advertencias);
+  else if (advertencias==1) fprintf(stderr, ", 1 warning\n");
    else printf("\n");
  remove("~tmppre.*");
  exit(0);

--- a/src/dura.y
+++ b/src/dura.y
@@ -1326,6 +1326,8 @@ int yywrap()
 
 void yyerror(char *s)
 {
+ /* print bison error message */
+ fprintf(stderr, "Parsing error: %s\n", s);
  hacer_error(0);
 }
 

--- a/src/lex.l
+++ b/src/lex.l
@@ -1,5 +1,5 @@
 %{
-#include"dura.h"
+#include "dura.tab.h"
 
 extern unsigned int ePC;
 extern unsigned char *original;

--- a/src/makefile
+++ b/src/makefile
@@ -13,4 +13,4 @@ parser3.o: parser3.l
 	flex -i -Pparser3 -oparser3.c parser3.l
 	gcc parser3.c -c -oparser3.o -Os
 clean:
-	rm -f *.o dura.{c,h} lex.c prog.c parser{1,2,3}.c asmsx
+	rm -f *.o dura.{c,h} lex.c prog.c parser{1,2,3}.c asmsx*

--- a/src/makefile
+++ b/src/makefile
@@ -1,24 +1,14 @@
-asmsx:	dura.tab.o lex.yy.o lex.parser1.o lex.parser2.o lex.parser3.o
-	gcc -Os -s -lm -o $@ $^
+asmsx:	dura.tab.c lex.yy.c lex.parser1.c lex.parser2.c lex.parser3.c
+	gcc $^ -o$@ -lm -Os -s
 dura.tab.c dura.tab.h:	dura.y
 	bison -d $<
-dura.tab.o:	dura.tab.c
-	gcc -c -Os $<
 lex.yy.c:	lex.l
 	flex -i $<
-lex.yy.o:	lex.yy.c
-	gcc -c -Os $<
 lex.parser1.c:	parser1.l
 	flex -i -Pparser1 $<
-lex.parser1.o:	lex.parser1.c
-	gcc -c -Os $<
 lex.parser2.c:	parser2.l
 	flex -i -Pparser2 $<
-lex.parser2.o:	lex.parser2.c
-	gcc -c -Os $<
 lex.parser3.c:	parser3.l
 	flex -i -Pparser3 $<
-lex.parser3.o:	lex.parser3.c
-	gcc -c -Os $<
 clean:
-	rm -f *.o *.tab.{c,h} lex.*.c asmsx*
+	rm -f *.o *.tab.* lex.*.c asmsx*

--- a/src/makefile
+++ b/src/makefile
@@ -1,24 +1,24 @@
 asmsx:	dura.o lex.o parser1.o parser2.o parser3.o
-	gcc dura.o lex.o parser1.o parser2.o parser3.o -oasmsx -Os -s -lm
+	gcc -Os -s -lm -o $@ $^
 dura.o:	dura.c
-	gcc -c -Os dura.c
+	gcc -c -Os $<
 dura.c:	dura.y
-	bison dura.y -odura.c -d
+	bison -d -o $@ $<
 lex.o:	lex.c
-	gcc -c -Os lex.c
+	gcc -c -Os $<
 lex.c:	lex.l
-	flex -i -olex.c lex.l
+	flex -i -o $@ $<
 parser1.c:	parser1.l
-	flex -i -Pparser1 -oparser1.c parser1.l
+	flex -i -Pparser1 -o $@ $<
 parser1.o:	parser1.c
-	gcc -c -Os parser1.c
+	gcc -c -Os $<
 parser2.c:	parser2.l
-	flex -i -Pparser2 -oparser2.c parser2.l
+	flex -i -Pparser2 -o $@ $<
 parser2.o:	parser2.c
-	gcc -c -Os parser2.c
+	gcc -c -Os $<
 parser3.c:	parser3.l
-	flex -i -Pparser3 -oparser3.c parser3.l
+	flex -i -Pparser3 -o $@ $<
 parser3.o:	parser3.c
-	gcc -c -Os parser3.c
+	gcc -c -Os $<
 clean:
 	rm -f *.o dura.{c,h} lex.c prog.c parser{1,2,3}.c asmsx*

--- a/src/makefile
+++ b/src/makefile
@@ -1,24 +1,24 @@
-asmsx:	dura.o lex.o parser1.o parser2.o parser3.o
+asmsx:	dura.tab.o lex.yy.o lex.parser1.o lex.parser2.o lex.parser3.o
 	gcc -Os -s -lm -o $@ $^
-dura.o:	dura.c
+dura.tab.c dura.tab.h:	dura.y
+	bison -d $<
+dura.tab.o:	dura.tab.c
 	gcc -c -Os $<
-dura.c:	dura.y
-	bison -d -o $@ $<
-lex.o:	lex.c
+lex.yy.c:	lex.l
+	flex -i $<
+lex.yy.o:	lex.yy.c
 	gcc -c -Os $<
-lex.c:	lex.l
-	flex -i -o $@ $<
-parser1.c:	parser1.l
-	flex -i -Pparser1 -o $@ $<
-parser1.o:	parser1.c
+lex.parser1.c:	parser1.l
+	flex -i -Pparser1 $<
+lex.parser1.o:	lex.parser1.c
 	gcc -c -Os $<
-parser2.c:	parser2.l
-	flex -i -Pparser2 -o $@ $<
-parser2.o:	parser2.c
+lex.parser2.c:	parser2.l
+	flex -i -Pparser2 $<
+lex.parser2.o:	lex.parser2.c
 	gcc -c -Os $<
-parser3.c:	parser3.l
-	flex -i -Pparser3 -o $@ $<
-parser3.o:	parser3.c
+lex.parser3.c:	parser3.l
+	flex -i -Pparser3 $<
+lex.parser3.o:	lex.parser3.c
 	gcc -c -Os $<
 clean:
-	rm -f *.o dura.{c,h} lex.c prog.c parser{1,2,3}.c asmsx*
+	rm -f *.o *.tab.{c,h} lex.*.c asmsx*

--- a/src/makefile
+++ b/src/makefile
@@ -1,16 +1,25 @@
-asmsx:	parser1.o parser2.o parser3.o dura.y lex.l
-	bison dura.y -odura.c -d
-	flex -i -olex.c lex.l
-	gcc dura.c lex.c parser1.o parser2.o parser3.o -oasmsx -Os -s -lm
+asmsx:	dura.o lex.o parser1.o parser2.o parser3.o
+	gcc dura.o lex.o parser1.o parser2.o parser3.o -oasmsx -Os -s -lm
 	strip -s asmsx
-parser1.o: parser1.l
+dura.o:	dura.c
+	gcc -c -Os dura.c
+dura.c:	dura.y
+	bison dura.y -odura.c -d
+lex.o:	lex.c
+	gcc -c -Os lex.c
+lex.c:	lex.l
+	flex -i -olex.c lex.l
+parser1.c:	parser1.l
 	flex -i -Pparser1 -oparser1.c parser1.l
-	gcc parser1.c -c -oparser1.o -Os
-parser2.o: parser2.l
+parser1.o:	parser1.c
+	gcc -c -Os parser1.c
+parser2.c:	parser2.l
 	flex -i -Pparser2 -oparser2.c parser2.l
-	gcc parser2.c -c -oparser2.o -Os
-parser3.o: parser3.l
+parser2.o:	parser2.c
+	gcc -c -Os parser2.c
+parser3.c:	parser3.l
 	flex -i -Pparser3 -oparser3.c parser3.l
-	gcc parser3.c -c -oparser3.o -Os
+parser3.o:	parser3.c
+	gcc -c -Os parser3.c
 clean:
 	rm -f *.o dura.{c,h} lex.c prog.c parser{1,2,3}.c asmsx*

--- a/src/makefile
+++ b/src/makefile
@@ -1,6 +1,5 @@
 asmsx:	dura.o lex.o parser1.o parser2.o parser3.o
 	gcc dura.o lex.o parser1.o parser2.o parser3.o -oasmsx -Os -s -lm
-	strip -s asmsx
 dura.o:	dura.c
 	gcc -c -Os dura.c
 dura.c:	dura.y

--- a/src/parser1.l
+++ b/src/parser1.l
@@ -15,14 +15,14 @@
 	#include <stdio.h>
 	#define MAX_INCLUDE_LEVEL 16
 
-	char *text,*tmpstr,*name,i,include_index=0;
-	FILE *output_file,*input_file;
+	char *p1_text,*p1_tmpstr,*p1_name,p1_i,p1_include_index=0;
+	FILE *p1_output_file,*p1_input_file;
  	struct
 	{
 		YY_BUFFER_STATE buffer;
 		unsigned int line;
   		char *name;
-	} include_stack[MAX_INCLUDE_LEVEL];
+	} p1_include_stack[MAX_INCLUDE_LEVEL];
 
 extern int prompt_error1(char);
 %}
@@ -36,44 +36,44 @@ extern int prompt_error1(char);
 
 %%
 
-<INITIAL>\42[^\42]*\42 strcat(text,yytext);
-<INITIAL>.?include/[ \042\t]+ tmpstr=NULL;BEGIN(inclusion);
+<INITIAL>\42[^\42]*\42 strcat(p1_text,yytext);
+<INITIAL>.?include/[ \042\t]+ p1_tmpstr=NULL;BEGIN(inclusion);
 <inclusion>[ \t]*      /* strip spaces */
-<inclusion>[^ \t\n]+   tmpstr=strtok(yytext,"\42");
+<inclusion>[^ \t\n]+   p1_tmpstr=strtok(yytext,"\42");
 <inclusion>\n {
-	if (tmpstr==NULL) prompt_error1(5);
-	if (tmpstr[strlen(tmpstr)-1]<=32) prompt_error1(1);
-	if (include_index>=MAX_INCLUDE_LEVEL) prompt_error1(2);
-	for (i=0;i<include_index;i++) if (!strcmp(tmpstr,include_stack[i].name)) prompt_error1(4);
-	include_stack[include_index].name=(char*)malloc(0x100);
-	strcpy(include_stack[include_index].name,name);
-	include_stack[include_index].line=yylineno;
-	include_stack[include_index++].buffer=YY_CURRENT_BUFFER;
-	yyin=fopen(tmpstr,"r");
+	if (p1_tmpstr==NULL) prompt_error1(5);
+	if (p1_tmpstr[strlen(p1_tmpstr)-1]<=32) prompt_error1(1);
+	if (p1_include_index>=MAX_INCLUDE_LEVEL) prompt_error1(2);
+	for (p1_i=0;p1_i<p1_include_index;p1_i++) if (!strcmp(p1_tmpstr,p1_include_stack[p1_i].name)) prompt_error1(4);
+	p1_include_stack[p1_include_index].name=(char*)malloc(0x100);
+	strcpy(p1_include_stack[p1_include_index].name,p1_name);
+	p1_include_stack[p1_include_index].line=yylineno;
+	p1_include_stack[p1_include_index++].buffer=YY_CURRENT_BUFFER;
+	yyin=fopen(p1_tmpstr,"r");
 	if (!yyin) prompt_error1(3);
-	printf("Including file %s\n",tmpstr);
+	printf("Including file %s\n",p1_tmpstr);
 	yylineno=1;
-	strcpy(name,tmpstr);
-	fprintf(output_file,"#file \042%s\042\n",name);
+	strcpy(p1_name,p1_tmpstr);
+	fprintf(p1_output_file,"#file \042%s\042\n",p1_name);
 	yy_switch_to_buffer(yy_create_buffer(yyin,YY_BUF_SIZE));
 	BEGIN(INITIAL);
 	}
 
 <<EOF>> {
 	fclose(yyin);
-	if (--include_index>=0)
+	if (--p1_include_index>=0)
 	{
 		yy_delete_buffer(YY_CURRENT_BUFFER);
-		yy_switch_to_buffer(include_stack[include_index].buffer);
-		yylineno=include_stack[include_index].line;
-		strcpy(name,include_stack[include_index].name);
-		fprintf(output_file,"#file \042%s\042\n",name);
-		free(include_stack[include_index].name);
+		yy_switch_to_buffer(p1_include_stack[p1_include_index].buffer);
+		yylineno=p1_include_stack[p1_include_index].line;
+		strcpy(p1_name,p1_include_stack[p1_include_index].name);
+		fprintf(p1_output_file,"#file \042%s\042\n",p1_name);
+		free(p1_include_stack[p1_include_index].name);
 	}
 	else
         {
-		if (strlen(text)>0) fprintf(output_file,"#line %d\n%s\n",yylineno,text);
-		fprintf(output_file,"%s",yytext);
+		if (strlen(p1_text)>0) fprintf(p1_output_file,"#line %d\n%s\n",yylineno,p1_text);
+		fprintf(p1_output_file,"%s",yytext);
 		return 0;
 	}
 	}
@@ -92,23 +92,23 @@ extern int prompt_error1(char);
 <pascal_comment>[^}]* /* Skip all within */
 <pascal_comment>"}" BEGIN(INITIAL);
 
-<INITIAL>\42 strcat(text,yytext);BEGIN(chain);
-<chain>\42 strcat(text,yytext);BEGIN(INITIAL);
+<INITIAL>\42 strcat(p1_text,yytext);BEGIN(chain);
+<chain>\42 strcat(p1_text,yytext);BEGIN(INITIAL);
 <chain>\n prompt_error1(1);
-<chain>[^\42\n] strcat(text,yytext);
+<chain>[^\42\n] strcat(p1_text,yytext);
 
-<INITIAL>[ \t]+ if (strlen(text)>0) strcat(text," "); // Should be 0 for Windows
-<INITIAL>\n     { if (strlen(text)>0) fprintf(output_file,"#line %d\n%s\n",yylineno-1,text);  // Should be 0 for Windows?
-         text[0]=0;
+<INITIAL>[ \t]+ if (strlen(p1_text)>0) strcat(p1_text," "); // Should be 0 for Windows
+<INITIAL>\n     { if (strlen(p1_text)>0) fprintf(p1_output_file,"#line %d\n%s\n",yylineno-1,p1_text);  // Should be 0 for Windows?
+         p1_text[0]=0;
        }
-<INITIAL>.      strcat(text,yytext);
+<INITIAL>.      strcat(p1_text,yytext);
 
 %%
 #define VERSION 
 
 int prompt_error1(char c)
 {
- fprintf(stderr, "%s, line %d: ",name,yylineno-1);
+ fprintf(stderr, "%s, line %d: ",p1_name,yylineno-1);
  switch (c)
  {
   case 1:fprintf(stderr, "Unterminated string");break;
@@ -117,7 +117,7 @@ int prompt_error1(char c)
   case 4:fprintf(stderr, "Recursive include");break;
   case 5:fprintf(stderr, "Wrong file name");break;
  }
- fclose(output_file);
+ fclose(p1_output_file);
  exit(c);
  return 0;
 }
@@ -130,19 +130,18 @@ int yywrap()
 int preprocessor1(char *input_name)
 {
 // Memory allocation for strings
- text=(char*)malloc(256);
- name=(char*)malloc(256);
- tmpstr=(char*)malloc(256);
- char *tmpstr_ = tmpstr;
+ p1_text=(char*)malloc(256);
+ p1_name=(char*)malloc(256);
+ p1_tmpstr=(char*)malloc(256);
 
 // Strings initialization
- text[0]=0;
+ p1_text[0]=0;
 
 // Get source code name
- strcpy(name,input_name);
+ strcpy(p1_name,input_name);
 
 // Open original source file
- if ((input_file=fopen(name,"r"))==NULL)
+ if ((p1_input_file=fopen(p1_name,"r"))==NULL)
  {
   fprintf(stderr, "Fatal: cannot open %s",input_name);
   exit(1);
@@ -151,23 +150,22 @@ int preprocessor1(char *input_name)
 // Print parsing message
  printf("Parsing file %s\n",input_name);
 
-// Create output_file file
- output_file=fopen("~tmppre.0","w");
- fprintf(output_file,"#file \042%s\042\n",name);
+// Create p1_output_file file
+ p1_output_file=fopen("~tmppre.0","w");
+ fprintf(p1_output_file,"#file \042%s\042\n",p1_name);
  
 // Start lexical scanner
- yyin=input_file;
+ yyin=p1_input_file;
  yylex();
  
-// Close output_file file
- fclose(output_file);
+// Close p1_output_file file
+ fclose(p1_output_file);
 
 // Free string pointers
- free(text);
- free(name);
- free(tmpstr_);
+ free(p1_text);
+ free(p1_name);
+ free(p1_tmpstr);
 
 // Done
  return 0;
 }
-

--- a/src/parser1.l
+++ b/src/parser1.l
@@ -108,14 +108,14 @@ extern int prompt_error1(char);
 
 int prompt_error1(char c)
 {
- printf("%s, line %d: ",name,yylineno-1);
+ fprintf(stderr, "%s, line %d: ",name,yylineno-1);
  switch (c)
  {
-  case 1:printf("Unterminated string");break;
-  case 2:printf("Nested include level overflow");break;
-  case 3:printf("Include file not found");break;
-  case 4:printf("Recursive include");break;
-  case 5:printf("Wrong file name");break;
+  case 1:fprintf(stderr, "Unterminated string");break;
+  case 2:fprintf(stderr, "Nested include level overflow");break;
+  case 3:fprintf(stderr, "Include file not found");break;
+  case 4:fprintf(stderr, "Recursive include");break;
+  case 5:fprintf(stderr, "Wrong file name");break;
  }
  fclose(output_file);
  exit(c);
@@ -144,7 +144,7 @@ int preprocessor1(char *input_name)
 // Open original source file
  if ((input_file=fopen(name,"r"))==NULL)
  {
-  printf("Fatal: cannot open %s",input_name);
+  fprintf(stderr, "Fatal: cannot open %s",input_name);
   exit(1);
  }
 

--- a/src/parser1.l
+++ b/src/parser1.l
@@ -24,7 +24,7 @@
   		char *name;
 	} include_stack[MAX_INCLUDE_LEVEL];
 
-extern prompt_error1(char);
+extern int prompt_error1(char);
 %}
 
 %option yylineno
@@ -106,7 +106,7 @@ extern prompt_error1(char);
 %%
 #define VERSION 
 
-prompt_error1(char c)
+int prompt_error1(char c)
 {
  printf("%s, line %d: ",name,yylineno-1);
  switch (c)
@@ -122,12 +122,12 @@ prompt_error1(char c)
  return 0;
 }
 
-yywrap()
+int yywrap()
 {
  return 1;
 }
 
-preprocessor1(char *input_name)
+int preprocessor1(char *input_name)
 {
 // Memory allocation for strings
  text=(char*)malloc(256);

--- a/src/parser2.l
+++ b/src/parser2.l
@@ -9,9 +9,9 @@
 
 %{
  #include<stdio.h>
- FILE *output;
- char *text,*buffer,nested=0,level;
- unsigned int number,lines,i;
+ FILE *p2_output;
+ char *p2_text,*p2_buffer,p2_nested=0,p2_level;
+ unsigned int p2_number,p2_lines,p2_i;
  int prompt_error2(char);
  extern void hacer_error(int);
 %}
@@ -23,46 +23,46 @@
 
 %%
 
-<INITIAL>"#"line[ \t]*[0-9]+\n strcat(text,yytext);lines=atoi(&yytext[5]);BEGIN(line);
+<INITIAL>"#"line[ \t]*[0-9]+\n strcat(p2_text,yytext);p2_lines=atoi(&yytext[5]);BEGIN(line);
 <line>.?rept[ \t]+ BEGIN(repnum);
-<line>. strcat(text,yytext);BEGIN(INITIAL);
+<line>. strcat(p2_text,yytext);BEGIN(INITIAL);
 <repnum>[0-9]+[ \t]* {
-             number=atoi(yytext);
-             buffer[0]=0;
-             text[0]=0;
+             p2_number=atoi(yytext);
+             p2_buffer[0]=0;
+             p2_text[0]=0;
              BEGIN(rept); }
-<rept>.?rept[ \t]+[0-9]+[ \t]* buffer=strcat(buffer,yytext);nested++;level++;
+<rept>.?rept[ \t]+[0-9]+[ \t]* p2_buffer=strcat(p2_buffer,yytext);p2_nested++;p2_level++;
 <rept>"#"line[ \t]*[0-9]+\n[ \t]*.?endr[ \t]*\n {
-              if (nested)
+              if (p2_nested)
                {
-                nested--;
-                buffer=strcat(buffer,yytext);
+                p2_nested--;
+                p2_buffer=strcat(p2_buffer,yytext);
                } else
               {
-               for (i=0;i<number;i++)
-                fprintf(output,"%s",buffer);
-               buffer[0]=0;
+               for (p2_i=0;p2_i<p2_number;p2_i++)
+                fprintf(p2_output,"%s",p2_buffer);
+               p2_buffer[0]=0;
                BEGIN(INITIAL);
               }
              }
-<rept>. buffer=strcat(text,yytext);
-<rept>\n   buffer=strcat(buffer,yytext);
+<rept>. p2_buffer=strcat(p2_text,yytext);
+<rept>\n   p2_buffer=strcat(p2_buffer,yytext);
 <rept><<EOF>> hacer_error(2);
 <repnum>.     prompt_error2(1);
-<INITIAL>\n   fprintf(output,"%s%s",text,yytext);text[0]=0;
-<INITIAL>.    strcat(text,yytext);
+<INITIAL>\n   fprintf(p2_output,"%s%s",p2_text,yytext);p2_text[0]=0;
+<INITIAL>.    strcat(p2_text,yytext);
 
 %%
 
 int prompt_error2(char c)
 {
- fprintf(stderr, ", line %d: ",lines);
+ fprintf(stderr, ", line %d: ",p2_lines);
  switch (c)
  {
   case 1:fprintf(stderr, "number expected in REPT");break;
   case 2:fprintf(stderr, "REPT without ENDR");break;
  }
- fclose(output);
+ fclose(p2_output);
  exit(c);
  return 0;
 }
@@ -79,9 +79,9 @@ int preprocessor2()
  int loop=0;
 
  filename=(char*)malloc(0x100);
- text=(char*)malloc(0x1000);
- buffer=(char*)malloc(0x4000);
- text[0]=0;
+ p2_text=(char*)malloc(0x1000);
+ p2_buffer=(char*)malloc(0x4000);
+ p2_text[0]=0;
 
  printf("Expanding system macros\n");
  do
@@ -100,20 +100,19 @@ int preprocessor2()
 
  sprintf(filename,"~tmppre.%i",loop+1);
 
- output=fopen(filename,"w");
- level=0;
- nested=0;
+ p2_output=fopen(filename,"w");
+ p2_level=0;
+ p2_nested=0;
  yylex();
 
  fclose(input);
- fclose(output);
+ fclose(p2_output);
 
-} while (level);
+} while (p2_level);
 
 // free(filename);
-// free(text);
-// free(buffer);
+// free(p2_text);
+// free(p2_buffer);
 
  return loop+1;
 }
-

--- a/src/parser2.l
+++ b/src/parser2.l
@@ -12,7 +12,8 @@
  FILE *output;
  char *text,*buffer,nested=0,level;
  unsigned int number,lines,i;
- extern prompt_error2(char);
+ int prompt_error2(char);
+ extern void hacer_error(int);
 %}
 
 %s rept
@@ -53,7 +54,7 @@
 
 %%
 
-prompt_error2(char c)
+int prompt_error2(char c)
 {
  printf(", line %d: ",lines);
  switch (c)
@@ -66,15 +67,16 @@ prompt_error2(char c)
  return 0;
 }
 
-yywrap()
+int yywrap()
 {
  return 1;
 }
 
-preprocessor2()
+int preprocessor2()
 {
  FILE *input;
- char *filename,loop=0;
+ char *filename;
+ int loop=0;
 
  filename=(char*)malloc(0x100);
  text=(char*)malloc(0x1000);

--- a/src/parser2.l
+++ b/src/parser2.l
@@ -56,11 +56,11 @@
 
 int prompt_error2(char c)
 {
- printf(", line %d: ",lines);
+ fprintf(stderr, ", line %d: ",lines);
  switch (c)
  {
-  case 1:printf("number expected in REPT");break;
-  case 2:printf("REPT without ENDR");break;
+  case 1:fprintf(stderr, "number expected in REPT");break;
+  case 2:fprintf(stderr, "REPT without ENDR");break;
  }
  fclose(output);
  exit(c);
@@ -90,7 +90,7 @@ int preprocessor2()
 
  if ((input=fopen(filename,"r"))==NULL)
  {
-  printf("Fatal: cannot process file");
+  fprintf(stderr, "Fatal: cannot process file");
   exit(1);
  }
 

--- a/src/parser3.l
+++ b/src/parser3.l
@@ -10,8 +10,8 @@
 
 %{
  #include<stdio.h>
- FILE *output;
- char *text;
+ FILE *p3_output;
+ char *p3_text;
 %}
 
 %s line
@@ -19,18 +19,18 @@
 
 %%
 
-<INITIAL>"#"line[ \t]*[0-9]+\n strcat(text,yytext);BEGIN(line);
-<INITIAL>\n   fprintf(output,"%s%s",text,yytext);text[0]=0;
-<INITIAL>.    strcat(text,yytext);
-<line>.?zilog[ \t]*\n strcat(text,yytext);BEGIN(zilog);
-<line>. strcat(text,yytext);BEGIN(INITIAL);
-<zilog>\42[^\42\n]+\42 strcat(text,yytext);
-<zilog>"(" strcat(text,"[");
-<zilog>")" strcat(text,"]");
-<zilog>"[" strcat(text,"(");
-<zilog>"]" strcat(text,")");
-<zilog>. strcat(text,yytext);
-<zilog>\n fprintf(output,"%s%s",text,yytext);text[0]=0;
+<INITIAL>"#"line[ \t]*[0-9]+\n strcat(p3_text,yytext);BEGIN(line);
+<INITIAL>\n   fprintf(p3_output,"%s%s",p3_text,yytext);p3_text[0]=0;
+<INITIAL>.    strcat(p3_text,yytext);
+<line>.?zilog[ \t]*\n strcat(p3_text,yytext);BEGIN(zilog);
+<line>. strcat(p3_text,yytext);BEGIN(INITIAL);
+<zilog>\42[^\42\n]+\42 strcat(p3_text,yytext);
+<zilog>"(" strcat(p3_text,"[");
+<zilog>")" strcat(p3_text,"]");
+<zilog>"[" strcat(p3_text,"(");
+<zilog>"]" strcat(p3_text,")");
+<zilog>. strcat(p3_text,yytext);
+<zilog>\n fprintf(p3_output,"%s%s",p3_text,yytext);p3_text[0]=0;
 
 %%
 
@@ -43,8 +43,8 @@ int preprocessor3()
 {
  FILE *input;
 
- text=(char*)malloc(0x1000);
- text[0]=0;
+ p3_text=(char*)malloc(0x1000);
+ p3_text[0]=0;
 
  if ((input=fopen("~tmppre.0","r"))==NULL)
  {
@@ -54,15 +54,14 @@ int preprocessor3()
 
  yyin=input;
  
- output=fopen("~tmppre.1","w");
+ p3_output=fopen("~tmppre.1","w");
 
  yylex();
 
  fclose(input);
- fclose(output);
+ fclose(p3_output);
 
- free(text);
+ free(p3_text);
  
  return 0;
 }
-

--- a/src/parser3.l
+++ b/src/parser3.l
@@ -48,7 +48,7 @@ int preprocessor3()
 
  if ((input=fopen("~tmppre.0","r"))==NULL)
  {
-  printf("Fatal: cannot process file");
+  fprintf(stderr, "Fatal: cannot process file");
   exit(1);
  }
 

--- a/src/parser3.l
+++ b/src/parser3.l
@@ -34,12 +34,12 @@
 
 %%
 
-yywrap()
+int yywrap()
 {
  return 1;
 }
 
-preprocessor3()
+int preprocessor3()
 {
  FILE *input;
 


### PR DESCRIPTION
1) addressed multiple implicit function return and parameter declarations by assigning explicit types;
2) fixed global variable name clash between dura.y, parser1.l, parser2.l and parser3.l;
3) provided extern definitions where needed;
4) modified makefile to be one action per rule, also use $< $^ and $@ macros for single and multiple file rule input and single file rule output;
5) changed asMSX error/warning output to stderr.