### PR TITLE
Fix issue #16 with cassette file name

### DIFF
--- a/src/dura.y
+++ b/src/dura.y
@@ -1544,9 +1544,6 @@ void finalizar()
 {
  unsigned int i;
  
- // Obtener nombre de la salida binaria
- strcpy(binario,filename);
-
  // Obtener nombre del archivo de s�mbolos
  strcpy(simbolos,filename);
  simbolos=strcat(simbolos,".sym");
@@ -1982,6 +1979,9 @@ int main(int argc, char *argv[])
  for (i=strlen(filename)-1;(filename[i]!='.')&&i;i--);
 
  if (i) filename[i]=0; else strcat(ensamblador,".asm");
+
+ // Obtener nombre de la salida binaria
+ strcpy(binario,filename);
 
  preprocessor1(ensamblador);
  preprocessor3();

--- a/src/dura.y
+++ b/src/dura.y
@@ -63,9 +63,14 @@
 	 v.0.17: [19/12/2013]
 		[FIX] Issue 1: Crash on Linux when including additional .asm files (by theNestruo)
 		[FIX] Issue 5: Non-zero exit code on errors (by theNestruo)
-	 v.0.18: 
+
+	 v.0.18: [01/02/2017]
 	 	Fixed issue with .megaflashrom and the defines.
 	 
+	 v.0.18.1: [11/02/2017]
+	 	Fixed multiple compilation warnings by specifying function parameters and return type explicitly
+                Fixed a problem with cassette file name generation due to uninitialized variable 'binario'
+
 */
 
 /* Cabecera y definiciones para C */
@@ -78,8 +83,8 @@
 #include<math.h>
 #include<ctype.h>
 
-#define VERSION "0.18"
-#define DATE "01/02/2017"
+#define VERSION "0.18.1"
+#define DATE "11/02/2017"
 
 #define Z80 0
 #define ROM 1

--- a/src/dura.y
+++ b/src/dura.y
@@ -76,6 +76,7 @@
 #include<string.h>
 #include<time.h>
 #include<math.h>
+#include<ctype.h>
 
 #define VERSION "0.18"
 #define DATE "01/02/2017"
@@ -1734,7 +1735,7 @@ void generar_cassette()
   if (strlen(interno)<6)
    for (i=strlen(interno);i<6;i++) interno[i]=32;
 
-  for (i=0;i<6;i++) fputc(interno[i],salida);
+  for (i=0;i<6;i++) fputc(toupper(interno[i]),salida);
 
   for (i=0;i<8;i++) fputc(cas[i],salida);
 


### PR DESCRIPTION
Cassette file name in variable `initio` was built using uninitialized string variable `binario`. asMSX 0.12g from 2008 didn't had this issue, but GPL release 0.16.1 got it. Fix is to move binario initialization from `finalizar()` to `main()`, right after `filename` and `ensamblador` initialization. I tested the fix and it works correctly.

I also added call to `toupper()`, because MSX BIOS always writes cassette file names in upper case.

Finally, I bumped the version from 0.18 to 0.18.1 and date from 01/02/2017 to 11/02/2017. I also provided a brief description or recent changes in `dura.y` header comment.