### PR TITLE
Add coding style document, format source to coding style guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Please read [asMSX manual](man/asmsx-en.md) to learn more.
 
 **DOWNLOAD:** You can find latest release [here](https://github.com/Fubukimaru/asMSX/releases/).
 
+If you'd like to contribute to this project, please take a look at our [coding style guide](man/coding-style.md)
+
 # Original Spanish README
 
 Estructura de carpetas

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please read [asMSX manual](man/asmsx-en.md) to learn more.
 
 **DOWNLOAD:** You can find latest release [here](https://github.com/Fubukimaru/asMSX/releases/).
 
-If you'd like to contribute to this project, please take a look at our [coding style guide](man/coding-style.md)
+If you'd like to contribute to this project, please take a look at our [coding style guide](man/coding-style.md).
 
 # Original Spanish README
 

--- a/man/coding-style.md
+++ b/man/coding-style.md
@@ -46,7 +46,7 @@ deeply nested 'if/else if/else' code or you have some other reasons to beleive i
 8. Try to address all the compiler warnings in your code: remove unused variables, avoid using uninitialized variables etc.
 9. Once the project starts using gtest/ctest, please add test units to cover new or changed code in your patch.
 10. Use static checking tools that are available: enable all the warnings in compiler, use a linter in Linux/BSD,
-use [cppcheck](http://cppcheck.sourceforge.net/) and Visual Studio Code Analysis tool.
+use [cppcheck](http://cppcheck.sourceforge.net/) and Visual Studio Code Analysis tool on Windows.
 11. If you can do it, please build your code on as many platforms as possible:
 Visual Studio 2017 on Windows 10, gcc on Linux, clang on BSD and Mac etc.
 Sometimes you'll find that header you think is everywhere, isn't everywhere.

--- a/man/coding-style.md
+++ b/man/coding-style.md
@@ -1,0 +1,49 @@
+
+# asMSX conding style
+
+If you want to contribute to asMSX, please consider following our shared guildelines for coding style
+
+## 1. Set your editor to use tabs and show them as 4 spaces
+
+## 2. Highlight tabs, spaces, cr and lf explicitly if your editor supports
+
+## 3. Use Allman brackets
+
+```
+function samplef(int a, int b, int c, int d)
+{
+    if (a == 1)
+    {
+        a_function();
+        if (b == 50)
+            c = 100;
+    }
+    else if ((a == BBB) && (d != 0))
+    {
+        another_function();
+	c = 200;
+    }
+    else
+    {
+        fprintf(stderr, "Unexpected value found: %d\n", a);
+        exit(1);
+    }
+}
+```
+
+1. Curly brackets are on their own line and start at the begining of the block.
+2. Don't add comments after curly brackets, put them above or below please.
+3. If you want to use `if () {} else if () {} else {};`, put `else if` and `else` on a separate line,
+idented same as starter `if`.
+4. If you have more then a couple of `else if`, consider using `switch()` instead.
+5. If block consist of single statement, don't use curly brackets, unless it is a very convoluted,
+deeply nested 'if/else if/else' code or you have some other reasons to beleive it will improve clarity.
+6. C99 `<stdint.h>` types are preferred, but plain C89 char/int/long with optional signed/unsigned qualifier are acceptable.
+7. Only do typecasts when necessary.
+8. Try to address all the compiler warnings in your code: remove unused variables, avoid using uninitialized variables etc.
+9. Once the project starts using gtest/ctest, please add test units to cover new or changed code in your patch.
+10. Use static checking tools that are available: enable all the warnings in compiler, use a linter in Linux/BSD,
+use [cppcheck](http://cppcheck.sourceforge.net/) and Visual Studio Code Analysis tool.
+11. If you can do it, please build your code on as many platforms as possible:
+Visual Studio 2017 on Windows 10, gcc on Linux, clang on BSD and Mac etc.
+Sometimes you'll find that header you think is everywhere, isn't everywhere.

--- a/man/coding-style.md
+++ b/man/coding-style.md
@@ -7,6 +7,9 @@ If you want to contribute to asMSX, please consider following our shared guildel
 
 ## 2. Highlight tabs, spaces, cr and lf explicitly if your editor supports
 
+In Visual Studio, press `Ctrl+E` and then `Ctrl+S`.
+For vim, add `set list` line to `.vimrc` file in your home directory.
+
 ## 3. Use Allman brackets
 
 ```

--- a/src/asmsx.c
+++ b/src/asmsx.c
@@ -424,3 +424,15 @@ void write_tape(
 		printf("Audio file %s saved [%2.2f sec]\n", fname_wav, (double)ws.samples_count / (ws.sample_rate * ws.num_channels * ws.bytes_per_sample));
 	}
 }
+
+/*
+ Deterministic version of rand() to keep generated binary files
+ consistent across platforms and compilers. Code snippet is from
+ http://stackoverflow.com/questions/4768180/rand-implementation
+*/
+static unsigned long int rand_seed = 1;
+int d_rand()
+{
+	rand_seed = (rand_seed * 1103515245 + 12345);
+	return (unsigned int)(rand_seed / 65536) % (32767 + 1);
+}

--- a/src/asmsx.c
+++ b/src/asmsx.c
@@ -238,8 +238,8 @@ void write_tape(
 	char fname_cas[PATH_MAX + 1];
 	char fname_wav[PATH_MAX + 1];
 	char _fname_msx[FNAME_MSX_LEN + 1];
-	FILE *wavf = NULL;
 	FILE *casf = NULL;
+	FILE *wavf = NULL;
 	int i;
 	struct WavHeader wh;
 
@@ -275,7 +275,7 @@ void write_tape(
 	{	/* 16 bit or higher samples */
 		ws.min_vol = -(int32_t)pow(2, ws.bytes_per_sample * 8 - 1);
 		ws.max_vol = -ws.min_vol - 1;
-		/* expand or remove assert if need to support samples 24-bit or higher samples */
+		/* expand or remove assert if need to support samples 24-bit or higher */
 		assert((ws.bytes_per_sample == 2) && (ws.min_vol == -32768) && (ws.max_vol == 32767));
 	}
 	

--- a/src/asmsx.c
+++ b/src/asmsx.c
@@ -228,8 +228,8 @@ void write_tape(
 	const char *rom_buf
 )
 {
-	char fname_cas[PATH_MAX + 1];
-	char fname_wav[PATH_MAX + 1];
+	char fname_cas[PATH_MAX];
+	char fname_wav[PATH_MAX];
 	char _fname_msx[FNAME_MSX_LEN + 1];
 	FILE *casf = NULL;
 	FILE *wavf = NULL;

--- a/src/asmsx.c
+++ b/src/asmsx.c
@@ -4,13 +4,6 @@
  * Wav writting code is based on research in https://github.com/oboroc/msxtape-py
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <assert.h>
-#include <stdint.h>
-#include <math.h>
-
 #include "asmsx.h"
 
 #define FNAME_MSX_LEN 6

--- a/src/asmsx.h
+++ b/src/asmsx.h
@@ -8,11 +8,12 @@
 #include <assert.h>
 #include <stdint.h>
 
+#ifndef PATH_MAX
 #ifdef WIN32
-#define PATH_MAX 4096
-#include <Windows.h>
+#define PATH_MAX (_MAX_PATH)
 #else
 #include <limits.h>
+#endif
 #endif
 
 /* rom type */

--- a/src/asmsx.h
+++ b/src/asmsx.h
@@ -32,3 +32,4 @@
 
 /* function declarations */
 extern void write_tape(const int, const char *, const char *, const int, const int, const int, const int, const char *);
+int d_rand();

--- a/src/asmsx.h
+++ b/src/asmsx.h
@@ -1,5 +1,13 @@
 #pragma once
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <math.h>
+#include <assert.h>
+#include <stdint.h>
+
 #ifdef WIN32
 #define PATH_MAX 4096
 #include <Windows.h>

--- a/src/dura.y
+++ b/src/dura.y
@@ -375,7 +375,7 @@ line:    pseudo_instruction EOL
         | mnemo_jump EOL
         | mnemo_call EOL
         | PREPRO_FILE TEXT EOL {
-            strcpy(fname_src, $2);
+            strncpy(fname_src, $2, PATH_MAX);
           }
         | PREPRO_LINE value EOL {
             lines = $2;
@@ -730,7 +730,7 @@ pseudo_instruction: PSEUDO_ORG value {
             if (conditional[conditional_level])
             {
               if (!fname_msx[0])
-                strcpy(fname_msx, $2);
+                strncpy(fname_msx, $2, PATH_MAX);
               cassette |= $1;
             }
           }
@@ -739,7 +739,7 @@ pseudo_instruction: PSEUDO_ORG value {
             {
               if (!fname_msx[0])
               {
-                strcpy(fname_msx, fname_bin);
+                strncpy(fname_msx, fname_bin, PATH_MAX);
                 fname_msx[strlen(fname_msx) - 1] = 0;
               }
               cassette |= $1;
@@ -749,7 +749,7 @@ pseudo_instruction: PSEUDO_ORG value {
             zilog = 1;
           }
         | PSEUDO_FILENAME TEXT {
-            strcpy(fname_no_ext, $2);
+            strncpy(fname_no_ext, $2, PATH_MAX);
           }
 ;
 
@@ -3774,7 +3774,7 @@ void write_bin()
 void finalize()
 {
   /* Generate the name of file with symbolic information */
-  strcpy(fname_sym, fname_no_ext);
+  strncpy(fname_sym, fname_no_ext, PATH_MAX);
   fname_sym = strcat(fname_sym, ".sym");
  
   write_bin();

--- a/src/dura.y
+++ b/src/dura.y
@@ -106,6 +106,8 @@
 #define FREQ_LO 0x8000
 #define SILENCE 0x0000
 
+const size_t rom_buf_size = 0x1000000;	/* 16 megabytes */
+
 extern FILE *yyin;		/* yyin is defined in Flex-generated lexer */
 extern int yylex(void);
 int preprocessor1(char *);	/* defined in parser1.l */
@@ -2914,1032 +2916,1010 @@ list_16bits: value_16bits {
 %%
 
 /* Additional C functions */
+
 void msx_bios()
 {
-  bios = 1;
-  /* BIOS routines */
-  register_symbol("CHKRAM", 0x0000, 0);
-  register_symbol("SYNCHR", 0x0008, 0);
-  register_symbol("RDSLT" , 0x000c, 0);
-  register_symbol("CHRGTR", 0x0010, 0);
-  register_symbol("WRSLT" , 0x0014, 0);
-  register_symbol("OUTDO" , 0x0018, 0);
-  register_symbol("CALSLT", 0x001c, 0);
-  register_symbol("DCOMPR", 0x0020, 0);
-  register_symbol("ENASLT", 0x0024, 0);
-  register_symbol("GETYPR", 0x0028, 0);
-  register_symbol("CALLF" , 0x0030, 0);
-  register_symbol("KEYINT", 0x0038, 0);
-  register_symbol("INITIO", 0x003b, 0);
-  register_symbol("INIFNK", 0x003e, 0);
-  register_symbol("DISSCR", 0x0041, 0);
-  register_symbol("ENASCR", 0x0044, 0);
-  register_symbol("WRTVDP", 0x0047, 0);
-  register_symbol("RDVRM" , 0x004a, 0);
-  register_symbol("WRTVRM", 0x004d, 0);
-  register_symbol("SETRD" , 0x0050, 0);
-  register_symbol("SETWRT", 0x0053, 0);
-  register_symbol("FILVRM", 0x0056, 0);
-  register_symbol("LDIRMV", 0x0059, 0);
-  register_symbol("LDIRVM", 0x005c, 0);
-  register_symbol("CHGMOD", 0x005f, 0);
-  register_symbol("CHGCLR", 0x0062, 0);
-  register_symbol("NMI"   , 0x0066, 0);
-  register_symbol("CLRSPR", 0x0069, 0);
-  register_symbol("INITXT", 0x006c, 0);
-  register_symbol("INIT32", 0x006f, 0);
-  register_symbol("INIGRP", 0x0072, 0);
-  register_symbol("INIMLT", 0x0075, 0);
-  register_symbol("SETTXT", 0x0078, 0);
-  register_symbol("SETT32", 0x007b, 0);
-  register_symbol("SETGRP", 0x007e, 0);
-  register_symbol("SETMLT", 0x0081, 0);
-  register_symbol("CALPAT", 0x0084, 0);
-  register_symbol("CALATR", 0x0087, 0);
-  register_symbol("GSPSIZ", 0x008a, 0);
-  register_symbol("GRPPRT", 0x008d, 0);
-  register_symbol("GICINI", 0x0090, 0);
-  register_symbol("WRTPSG", 0x0093, 0);
-  register_symbol("RDPSG" , 0x0096, 0);
-  register_symbol("STRTMS", 0x0099, 0);
-  register_symbol("CHSNS" , 0x009c, 0);
-  register_symbol("CHGET" , 0x009f, 0);
-  register_symbol("CHPUT" , 0x00a2, 0);
-  register_symbol("LPTOUT", 0x00a5, 0);
-  register_symbol("LPTSTT", 0x00a8, 0);
-  register_symbol("CNVCHR", 0x00ab, 0);
-  register_symbol("PINLIN", 0x00ae, 0);
-  register_symbol("INLIN" , 0x00b1, 0);
-  register_symbol("QINLIN", 0x00b4, 0);
-  register_symbol("BREAKX", 0x00b7, 0);
-  register_symbol("ISCNTC", 0x00ba, 0);
-  register_symbol("CKCNTC", 0x00bd, 0);
-  register_symbol("BEEP"  , 0x00c0, 0);
-  register_symbol("CLS"   , 0x00c3, 0);
-  register_symbol("POSIT" , 0x00c6, 0);
-  register_symbol("FNKSB" , 0x00c9, 0);
-  register_symbol("ERAFNK", 0x00cc, 0);
-  register_symbol("DSPFNK", 0x00cf, 0);
-  register_symbol("TOTEXT", 0x00d2, 0);
-  register_symbol("GTSTCK", 0x00d5, 0);
-  register_symbol("GTTRIG", 0x00d8, 0);
-  register_symbol("GTPAD" , 0x00db, 0);
-  register_symbol("GTPDL" , 0x00de, 0);
-  register_symbol("TAPION", 0x00e1, 0);
-  register_symbol("TAPIN" , 0x00e4, 0);
-  register_symbol("TAPIOF", 0x00e7, 0);
-  register_symbol("TAPOON", 0x00ea, 0);
-  register_symbol("TAPOUT", 0x00ed, 0);
-  register_symbol("TAPOOF", 0x00f0, 0);
-  register_symbol("STMOTR", 0x00f3, 0);
-  register_symbol("LFTQ"  , 0x00f6, 0);
-  register_symbol("PUTQ"  , 0x00f9, 0);
-  register_symbol("RIGHTC", 0x00fc, 0);
-  register_symbol("LEFTC" , 0x00ff, 0);
-  register_symbol("UPC"   , 0x0102, 0);
-  register_symbol("TUPC"  , 0x0105, 0);
-  register_symbol("DOWNC" , 0x0108, 0);
-  register_symbol("TDOWNC", 0x010b, 0);
-  register_symbol("SCALXY", 0x010e, 0);
-  register_symbol("MAPXYC", 0x0111, 0);
-  register_symbol("FETCHC", 0x0114, 0);
-  register_symbol("STOREC", 0x0117, 0);
-  register_symbol("SETATR", 0x011a, 0);
-  register_symbol("READC" , 0x011d, 0);
-  register_symbol("SETC"  , 0x0120, 0);
-  register_symbol("NSETCX", 0x0123, 0);
-  register_symbol("GTASPC", 0x0126, 0);
-  register_symbol("PNTINI", 0x0129, 0);
-  register_symbol("SCANR" , 0x012c, 0);
-  register_symbol("SCANL" , 0x012f, 0);
-  register_symbol("CHGCAP", 0x0132, 0);
-  register_symbol("CHGSND", 0x0135, 0);
-  register_symbol("RSLREG", 0x0138, 0);
-  register_symbol("WSLREG", 0x013b, 0);
-  register_symbol("RDVDP" , 0x013e, 0);
-  register_symbol("SNSMAT", 0x0141, 0);
-  register_symbol("PHYDIO", 0x0144, 0);
-  register_symbol("FORMAT", 0x0147, 0);
-  register_symbol("ISFLIO", 0x014a, 0);
-  register_symbol("OUTDLP", 0x014d, 0);
-  register_symbol("GETVCP", 0x0150, 0);
-  register_symbol("GETVC2", 0x0153, 0);
-  register_symbol("KILBUF", 0x0156, 0);
-  register_symbol("CALBAS", 0x0159, 0);
-  register_symbol("SUBROM", 0x015c, 0);
-  register_symbol("EXTROM", 0x015f, 0);
-  register_symbol("CHKSLZ", 0x0162, 0);
-  register_symbol("CHKNEW", 0x0165, 0);
-  register_symbol("EOL"   , 0x0168, 0);
-  register_symbol("BIGFIL", 0x016b, 0);
-  register_symbol("NSETRD", 0x016e, 0);
-  register_symbol("NSTWRT", 0x0171, 0);
-  register_symbol("NRDVRM", 0x0174, 0);
-  register_symbol("NWRVRM", 0x0177, 0);
-  register_symbol("RDBTST", 0x017a, 0);
-  register_symbol("WRBTST", 0x017d, 0);
-  register_symbol("CHGCPU", 0x0180, 0);
-  register_symbol("GETCPU", 0x0183, 0);
-  register_symbol("PCMPLY", 0x0186, 0);
-  register_symbol("PCMREC", 0x0189, 0);
+	bios = 1;
+	/* BIOS routines */
+	register_symbol("CHKRAM", 0x0000, 0);
+	register_symbol("SYNCHR", 0x0008, 0);
+	register_symbol("RDSLT" , 0x000c, 0);
+	register_symbol("CHRGTR", 0x0010, 0);
+	register_symbol("WRSLT" , 0x0014, 0);
+	register_symbol("OUTDO" , 0x0018, 0);
+	register_symbol("CALSLT", 0x001c, 0);
+	register_symbol("DCOMPR", 0x0020, 0);
+	register_symbol("ENASLT", 0x0024, 0);
+	register_symbol("GETYPR", 0x0028, 0);
+	register_symbol("CALLF" , 0x0030, 0);
+	register_symbol("KEYINT", 0x0038, 0);
+	register_symbol("INITIO", 0x003b, 0);
+	register_symbol("INIFNK", 0x003e, 0);
+	register_symbol("DISSCR", 0x0041, 0);
+	register_symbol("ENASCR", 0x0044, 0);
+	register_symbol("WRTVDP", 0x0047, 0);
+	register_symbol("RDVRM" , 0x004a, 0);
+	register_symbol("WRTVRM", 0x004d, 0);
+	register_symbol("SETRD" , 0x0050, 0);
+	register_symbol("SETWRT", 0x0053, 0);
+	register_symbol("FILVRM", 0x0056, 0);
+	register_symbol("LDIRMV", 0x0059, 0);
+	register_symbol("LDIRVM", 0x005c, 0);
+	register_symbol("CHGMOD", 0x005f, 0);
+	register_symbol("CHGCLR", 0x0062, 0);
+	register_symbol("NMI"   , 0x0066, 0);
+	register_symbol("CLRSPR", 0x0069, 0);
+	register_symbol("INITXT", 0x006c, 0);
+	register_symbol("INIT32", 0x006f, 0);
+	register_symbol("INIGRP", 0x0072, 0);
+	register_symbol("INIMLT", 0x0075, 0);
+	register_symbol("SETTXT", 0x0078, 0);
+	register_symbol("SETT32", 0x007b, 0);
+	register_symbol("SETGRP", 0x007e, 0);
+	register_symbol("SETMLT", 0x0081, 0);
+	register_symbol("CALPAT", 0x0084, 0);
+	register_symbol("CALATR", 0x0087, 0);
+	register_symbol("GSPSIZ", 0x008a, 0);
+	register_symbol("GRPPRT", 0x008d, 0);
+	register_symbol("GICINI", 0x0090, 0);
+	register_symbol("WRTPSG", 0x0093, 0);
+	register_symbol("RDPSG" , 0x0096, 0);
+	register_symbol("STRTMS", 0x0099, 0);
+	register_symbol("CHSNS" , 0x009c, 0);
+	register_symbol("CHGET" , 0x009f, 0);
+	register_symbol("CHPUT" , 0x00a2, 0);
+	register_symbol("LPTOUT", 0x00a5, 0);
+	register_symbol("LPTSTT", 0x00a8, 0);
+	register_symbol("CNVCHR", 0x00ab, 0);
+	register_symbol("PINLIN", 0x00ae, 0);
+	register_symbol("INLIN" , 0x00b1, 0);
+	register_symbol("QINLIN", 0x00b4, 0);
+	register_symbol("BREAKX", 0x00b7, 0);
+	register_symbol("ISCNTC", 0x00ba, 0);
+	register_symbol("CKCNTC", 0x00bd, 0);
+	register_symbol("BEEP"  , 0x00c0, 0);
+	register_symbol("CLS"   , 0x00c3, 0);
+	register_symbol("POSIT" , 0x00c6, 0);
+	register_symbol("FNKSB" , 0x00c9, 0);
+	register_symbol("ERAFNK", 0x00cc, 0);
+	register_symbol("DSPFNK", 0x00cf, 0);
+	register_symbol("TOTEXT", 0x00d2, 0);
+	register_symbol("GTSTCK", 0x00d5, 0);
+	register_symbol("GTTRIG", 0x00d8, 0);
+	register_symbol("GTPAD" , 0x00db, 0);
+	register_symbol("GTPDL" , 0x00de, 0);
+	register_symbol("TAPION", 0x00e1, 0);
+	register_symbol("TAPIN" , 0x00e4, 0);
+	register_symbol("TAPIOF", 0x00e7, 0);
+	register_symbol("TAPOON", 0x00ea, 0);
+	register_symbol("TAPOUT", 0x00ed, 0);
+	register_symbol("TAPOOF", 0x00f0, 0);
+	register_symbol("STMOTR", 0x00f3, 0);
+	register_symbol("LFTQ"  , 0x00f6, 0);
+	register_symbol("PUTQ"  , 0x00f9, 0);
+	register_symbol("RIGHTC", 0x00fc, 0);
+	register_symbol("LEFTC" , 0x00ff, 0);
+	register_symbol("UPC"   , 0x0102, 0);
+	register_symbol("TUPC"  , 0x0105, 0);
+	register_symbol("DOWNC" , 0x0108, 0);
+	register_symbol("TDOWNC", 0x010b, 0);
+	register_symbol("SCALXY", 0x010e, 0);
+	register_symbol("MAPXYC", 0x0111, 0);
+	register_symbol("FETCHC", 0x0114, 0);
+	register_symbol("STOREC", 0x0117, 0);
+	register_symbol("SETATR", 0x011a, 0);
+	register_symbol("READC" , 0x011d, 0);
+	register_symbol("SETC"  , 0x0120, 0);
+	register_symbol("NSETCX", 0x0123, 0);
+	register_symbol("GTASPC", 0x0126, 0);
+	register_symbol("PNTINI", 0x0129, 0);
+	register_symbol("SCANR" , 0x012c, 0);
+	register_symbol("SCANL" , 0x012f, 0);
+	register_symbol("CHGCAP", 0x0132, 0);
+	register_symbol("CHGSND", 0x0135, 0);
+	register_symbol("RSLREG", 0x0138, 0);
+	register_symbol("WSLREG", 0x013b, 0);
+	register_symbol("RDVDP" , 0x013e, 0);
+	register_symbol("SNSMAT", 0x0141, 0);
+	register_symbol("PHYDIO", 0x0144, 0);
+	register_symbol("FORMAT", 0x0147, 0);
+	register_symbol("ISFLIO", 0x014a, 0);
+	register_symbol("OUTDLP", 0x014d, 0);
+	register_symbol("GETVCP", 0x0150, 0);
+	register_symbol("GETVC2", 0x0153, 0);
+	register_symbol("KILBUF", 0x0156, 0);
+	register_symbol("CALBAS", 0x0159, 0);
+	register_symbol("SUBROM", 0x015c, 0);
+	register_symbol("EXTROM", 0x015f, 0);
+	register_symbol("CHKSLZ", 0x0162, 0);
+	register_symbol("CHKNEW", 0x0165, 0);
+	register_symbol("EOL"   , 0x0168, 0);
+	register_symbol("BIGFIL", 0x016b, 0);
+	register_symbol("NSETRD", 0x016e, 0);
+	register_symbol("NSTWRT", 0x0171, 0);
+	register_symbol("NRDVRM", 0x0174, 0);
+	register_symbol("NWRVRM", 0x0177, 0);
+	register_symbol("RDBTST", 0x017a, 0);
+	register_symbol("WRBTST", 0x017d, 0);
+	register_symbol("CHGCPU", 0x0180, 0);
+	register_symbol("GETCPU", 0x0183, 0);
+	register_symbol("PCMPLY", 0x0186, 0);
+	register_symbol("PCMREC", 0x0189, 0);
 }
 
 void error_message(int n)
 {
-  printf("%s, line %d: ", strtok(fname_src, "\042"), lines);
-  switch (n)
-  {
-    case 0:
-      fprintf(stderr, "syntax error\n");
-      break;
-    case 1:
-      fprintf(stderr, "memory overflow\n");
-      break;
-    case 2:
-      fprintf(stderr, "wrong register combination\n");
-      break;
-    case 3:
-      fprintf(stderr, "wrong interruption mode\n");
-      break;
-    case 4:
-      fprintf(stderr, "destiny register should be A\n");
-      break;
-    case 5:
-      fprintf(stderr, "source register should be A\n");break;
-    case 6:
-      fprintf(stderr, "value should be 0\n");
-      break;
-    case 7:
-      fprintf(stderr, "missing condition\n");
-      break;
-    case 8:
-      fprintf(stderr, "unreachable address\n");
-      break;
-    case 9:
-      fprintf(stderr, "wrong condition\n");
-      break;
-    case 10:
-      fprintf(stderr, "wrong restart address\n");
-      break;
-    case 11:
-      fprintf(stderr, "symbol table overflow\n");
-      break;
-    case 12:
-      fprintf(stderr, "undefined identifier\n");
-      break;
-    case 13:
-      fprintf(stderr, "undefined local label\n");
-      break;
-    case 14:
-      fprintf(stderr, "symbol redefinition\n");
-      break;
-    case 15:
-      fprintf(stderr, "size redefinition\n");
-      break;
-    case 16:
-      fprintf(stderr, "reserved word used as identifier\n");
-      break;
-    case 17:
-      fprintf(stderr, "code size overflow\n");
-      break;
-    case 18:
-      fprintf(stderr, "binary file not found\n");
-      break;
-    case 19:
-      fprintf(stderr, "ROM directive should preceed any code\n");
-      break;
-    case 20:
-      fprintf(stderr, "type previously defined\n");
-      break;
-    case 21:
-      fprintf(stderr, "BASIC directive should preceed any code\n");
-      break;
-    case 22:
-      fprintf(stderr, "page out of range\n");
-      break;
-    case 23:
-      fprintf(stderr, "MSXDOS directive should preceed any code\n");
-      break;
-    case 24:
-      fprintf(stderr, "no code in the whole file\n");
-      break;
-    case 25:
-      fprintf(stderr, "only available for MSXDOS\n");
-      break;
-    case 26:
-      fprintf(stderr, "machine not defined\n");
-      break;
-    case 27:
-      fprintf(stderr, "MegaROM directive should preceed any code\n");
-      break;
-    case 28:
-      fprintf(stderr, "cannot write ROM code/data to page 3\n");
-      break;
-    case 29:
-      fprintf(stderr, "included binary shorter than expected\n");
-      break;
-    case 30:
-      fprintf(stderr, "wrong number of bytes to skip/include\n");
-      break;
-    case 31:
-      fprintf(stderr, "megaROM subpage overflow\n");
-      break;
-    case 32:
-      fprintf(stderr, "subpage 0 can only be defined by megaROM directive\n");
-      break;
-    case 33:
-      fprintf(stderr, "unsupported mapper type\n");
-      break;
-    case 34:
-      fprintf(stderr, "megaROM code should be between 4000h and BFFFh\n");
-      break;
-    case 35:
-      fprintf(stderr, "code/data without subpage\n");
-      break;
-    case 36:
-      fprintf(stderr, "megaROM mapper subpage out of range\n");
-      break;
-    case 37:
-      fprintf(stderr, "megaROM subpage already defined\n");
-      break;
-    case 38:
-      fprintf(stderr, "Konami megaROM forces page 0 at 4000h\n");
-      break;
-    case 39:
-      fprintf(stderr, "megaROM subpage not defined\n");
-      break;
-    case 40:
-      fprintf(stderr, "megaROM-only macro used\n");
-      break;
-    case 41:
-      fprintf(stderr, "only for ROMs and megaROMs\n");
-      break;
-    case 42:
-      fprintf(stderr, "ELSE without IF\n");
-      break;
-    case 43:
-      fprintf(stderr, "ENDIF without IF\n");
-      break;
-    case 44:
-      fprintf(stderr, "Cannot nest more IF's\n");
-      break;
-    case 45:
-      fprintf(stderr, "IF not closed\n");
-      break;
-    case 46:
-      fprintf(stderr, "Sinclair directive should preceed any code\n");
-      break;
-    default:
-      fprintf(stderr, "Unexpected error code %d\n", n);
-  }
-  remove("~tmppre.?");
-  exit(n + 1);
+	fprintf(stderr, "%s, line %d: ", strtok(fname_src, "\042"), lines);
+
+	switch (n)
+	{
+		case 0:
+			fprintf(stderr, "syntax error\n");
+			break;
+		case 1:
+			fprintf(stderr, "memory overflow\n");
+			break;
+		case 2:
+			fprintf(stderr, "wrong register combination\n");
+			break;
+		case 3:
+			fprintf(stderr, "wrong interruption mode\n");
+			break;
+		case 4:
+			fprintf(stderr, "destiny register should be A\n");
+			break;
+		case 5:
+			fprintf(stderr, "source register should be A\n");
+			break;
+		case 6:
+			fprintf(stderr, "value should be 0\n");
+			break;
+		case 7:
+			fprintf(stderr, "missing condition\n");
+			break;
+		case 8:
+			fprintf(stderr, "unreachable address\n");
+			break;
+		case 9:
+			fprintf(stderr, "wrong condition\n");
+			break;
+		case 10:
+			fprintf(stderr, "wrong restart address\n");
+			break;
+		case 11:
+			fprintf(stderr, "symbol table overflow\n");
+			break;
+		case 12:
+			fprintf(stderr, "undefined identifier\n");
+			break;
+		case 13:
+			fprintf(stderr, "undefined local label\n");
+			break;
+		case 14:
+			fprintf(stderr, "symbol redefinition\n");
+			break;
+		case 15:
+			fprintf(stderr, "size redefinition\n");
+			break;
+		case 16:
+			fprintf(stderr, "reserved word used as identifier\n");
+			break;
+		case 17:
+			fprintf(stderr, "code size overflow\n");
+			break;
+		case 18:
+			fprintf(stderr, "binary file not found\n");
+			break;
+		case 19:
+			fprintf(stderr, "ROM directive should preceed any code\n");
+			break;
+		case 20:
+			fprintf(stderr, "type previously defined\n");
+			break;
+		case 21:
+			fprintf(stderr, "BASIC directive should preceed any code\n");
+			break;
+		case 22:
+			fprintf(stderr, "page out of range\n");
+			break;
+		case 23:
+			fprintf(stderr, "MSXDOS directive should preceed any code\n");
+			break;
+		case 24:
+			fprintf(stderr, "no code in the whole file\n");
+			break;
+		case 25:
+			fprintf(stderr, "only available for MSXDOS\n");
+			break;
+		case 26:
+			fprintf(stderr, "machine not defined\n");
+			break;
+		case 27:
+			fprintf(stderr, "MegaROM directive should preceed any code\n");
+			break;
+		case 28:
+			fprintf(stderr, "cannot write ROM code/data to page 3\n");
+			break;
+		case 29:
+			fprintf(stderr, "included binary shorter than expected\n");
+			break;
+		case 30:
+			fprintf(stderr, "wrong number of bytes to skip/include\n");
+			break;
+		case 31:
+			fprintf(stderr, "megaROM subpage overflow\n");
+			break;
+		case 32:
+			fprintf(stderr, "subpage 0 can only be defined by megaROM directive\n");
+			break;
+		case 33:
+			fprintf(stderr, "unsupported mapper type\n");
+			break;
+		case 34:
+			fprintf(stderr, "megaROM code should be between 4000h and BFFFh\n");
+			break;
+		case 35:
+			fprintf(stderr, "code/data without subpage\n");
+			break;
+		case 36:
+			fprintf(stderr, "megaROM mapper subpage out of range\n");
+			break;
+		case 37:
+			fprintf(stderr, "megaROM subpage already defined\n");
+			break;
+		case 38:
+			fprintf(stderr, "Konami megaROM forces page 0 at 4000h\n");
+			break;
+		case 39:
+			fprintf(stderr, "megaROM subpage not defined\n");
+			break;
+		case 40:
+			fprintf(stderr, "megaROM-only macro used\n");
+			break;
+		case 41:
+			fprintf(stderr, "only for ROMs and megaROMs\n");
+			break;
+		case 42:
+			fprintf(stderr, "ELSE without IF\n");
+			break;
+		case 43:
+			fprintf(stderr, "ENDIF without IF\n");
+			break;
+		case 44:
+			fprintf(stderr, "Cannot nest more IF's\n");
+			break;
+		case 45:
+			fprintf(stderr, "IF not closed\n");
+			break;
+		case 46:
+			fprintf(stderr, "Sinclair directive should preceed any code\n");
+			break;
+		default:
+			fprintf(stderr, "Unexpected error code %d\n", n);
+	}
+	remove("~tmppre.?");
+	exit(n + 1);
 }
 
 void warning_message(int n)
 {
-  if (pass != 2)
-    return;
+	if (pass != 2)
+		return;
 
-  printf("%s, line %d: Warning: ", strtok(fname_src, "\042"), lines);
-  switch (n)
-  {
-    case 0:
-      fprintf(stderr, "undefined error\n");
-      break;
-    case 1:
-      fprintf(stderr, "16-bit overflow\n");
-      break;
-    case 2:
-      fprintf(stderr, "8-bit overflow\n");
-      break;
-    case 3:
-      fprintf(stderr, "3-bit overflow\n");
-      break;
-    case 4:
-      fprintf(stderr, "output cannot be converted to CAS\n");
-      break;
-    case 5:
-      fprintf(stderr, "non official Zilog syntax\n");
-      break;
-    case 6:
-      fprintf(stderr, "undocumented Zilog instruction\n");
-      break;
-    default:
-      fprintf(stderr, "unexpected warning %d\n", n);
-  }
-  warnings++;
+	fprintf(stderr, "%s, line %d: Warning: ", strtok(fname_src, "\042"), lines);
+	switch (n)
+	{
+		case 0:
+			fprintf(stderr, "undefined error\n");
+			break;
+		case 1:
+			fprintf(stderr, "16-bit overflow\n");
+			break;
+		case 2:
+			fprintf(stderr, "8-bit overflow\n");
+			break;
+		case 3:
+			fprintf(stderr, "3-bit overflow\n");
+			break;
+		case 4:
+			fprintf(stderr, "output cannot be converted to CAS\n");
+			break;
+		case 5:
+			fprintf(stderr, "non official Zilog syntax\n");
+			break;
+		case 6:
+			fprintf(stderr, "undocumented Zilog instruction\n");
+			break;
+		default:
+			fprintf(stderr, "unexpected warning %d\n", n);
+	}
+	warnings++;
 }
 
 /* Generate byte */
 void write_byte(int b)
 {
-  /* If the condition of this block is fulfilled, create the code */
-  if ((!conditional_level) || (conditional[conditional_level]))
-  {
-    if (rom_type != MEGAROM)
-    {
-      if (PC >= 0x10000)
-        error_message(1);
+	/* If the condition of this block is fulfilled, create the code */
+	if ((!conditional_level) || (conditional[conditional_level]))
+	{
+		if (rom_type != MEGAROM)
+		{
+			if (PC >= 0x10000)
+				error_message(1);
 
-      if ((rom_type == ROM) && (PC >= 0xC000))
-        error_message(28);
+			if ((rom_type == ROM) && (PC >= 0xC000))
+				error_message(28);
 
-      if (start_address > PC)
-        start_address = PC;
+			if (start_address > PC)
+				start_address = PC;
 
-      if (end_address < PC)
-        end_address = PC;
+			if (end_address < PC)
+				end_address = PC;
 
-      if (size && (PC >= start_address + size * 1024) && (pass == 2))
-        error_message(17);
+			if (size && (PC >= start_address + size * 1024) && (pass == 2))
+				error_message(17);
 
-      if (size && (start_address + size * 1024 > 65536) && (pass == 2))
-        error_message(1);
+			if (size && (start_address + size * 1024 > 65536) && (pass == 2))
+				error_message(1);
 
-      rom_buf[PC++] = (char)b;
-      ePC++;
-    }
-    else
-    {	/* if (type == MEGAROM) */
-      if (subpage == 0x100)
-        error_message(35);
+			rom_buf[PC++] = (char)b;
+			ePC++;
+		}
+		else
+		{
+			/* if (type == MEGAROM) */
+			if (subpage == 0x100)
+				error_message(35);
 
-      if (PC >= pageinit + 1024 * pagesize)
-        error_message(31);
+			if (PC >= pageinit + 1024 * pagesize)
+				error_message(31);
 
-      rom_buf[subpage * pagesize * 1024 + PC - pageinit] = (char)b;
-      PC++;
-      ePC++;
-    }
-  }
+			rom_buf[subpage * pagesize * 1024 + PC - pageinit] = (char)b;
+			PC++;
+			ePC++;
+		}
+	}
 }
 
 void write_string(char *str)
 {
-  size_t t;
-  for (t = 0; t < strlen(str); t++)
-    write_byte((int)str[t]);
+	size_t t;
+	for (t = 0; t < strlen(str); t++)
+		write_byte((int)str[t]);
 }
 
 void write_word(int w)
 {
-  write_byte(w & 0xff);
-  write_byte((w >> 8) & 0xff);
+	write_byte(w & 0xff);
+	write_byte((w >> 8) & 0xff);
 }
 
 void relative_jump(int direction)
 {
-  int jump;
+	int jump;
 
-  jump = direction - ePC - 1;
+	jump = direction - ePC - 1;
 
-  if ((jump > 127) || (jump < -128))
-    error_message(8);
+	if ((jump > 127) || (jump < -128))
+		error_message(8);
 
-  write_byte(jump);
+	write_byte(jump);
 }
 
 void register_label(char *name)
 {
-  int i;
+	int i;
 
-  if (pass == 2)
-    for (i = 0; i < total_global; i++)
-      if (!strcmp(name, id_list[i].name))
-      {
-        last_global = i;
-        return;
-      }
+	if (pass == 2)
+		for (i = 0; i < total_global; i++)
+			if (!strcmp(name, id_list[i].name))
+			{
+				last_global = i;
+				return;
+			}
 
-  for (i = 0; i < total_global; i++)
-    if (!strcmp(name, id_list[i].name))
-      error_message(14);
+	for (i = 0; i < total_global; i++)
+		if (!strcmp(name, id_list[i].name))
+			error_message(14);
 
-  if (++total_global == MAX_ID)
-    error_message(11);
+	if (++total_global == MAX_ID)
+		error_message(11);
 
-  id_list[total_global - 1].name = malloc(strlen(name) + 4);
-  strcpy(id_list[total_global - 1].name, name);
-  id_list[total_global - 1].value = ePC;
-  id_list[total_global - 1].type = 1;
-  id_list[total_global - 1].page = subpage;
-  last_global = total_global - 1;
+	id_list[total_global - 1].name = malloc(strlen(name) + 4);
+	strcpy(id_list[total_global - 1].name, name);
+	id_list[total_global - 1].value = ePC;
+	id_list[total_global - 1].type = 1;
+	id_list[total_global - 1].page = subpage;
+	last_global = total_global - 1;
 }
 
 void register_local(char *name)
 {
-  int i;
+	int i;
 
-  if (pass == 2)
-    return;
+	if (pass == 2)
+		return;
 
-  for (i = last_global; i < total_global; i++)
-    if (!strcmp(name, id_list[i].name))
-      error_message(14);
+	for (i = last_global; i < total_global; i++)
+		if (!strcmp(name, id_list[i].name))
+			error_message(14);
 
-  if (++total_global == MAX_ID)
-    error_message(11);
+	if (++total_global == MAX_ID)
+		error_message(11);
 
-  id_list[total_global - 1].name = malloc(strlen(name) + 4);
-  strcpy(id_list[total_global - 1].name, name);
-  id_list[total_global - 1].value = ePC;
-  id_list[total_global - 1].type = 1;
-  id_list[total_global - 1].page = subpage;
+	id_list[total_global - 1].name = malloc(strlen(name) + 4);
+	strcpy(id_list[total_global - 1].name, name);
+	id_list[total_global - 1].value = ePC;
+	id_list[total_global - 1].type = 1;
+	id_list[total_global - 1].page = subpage;
 }
 
 void register_symbol(char *name, int n, int rom_type)
 {
-  int i;
-  char *_name;
+	int i;
+	char *_name;
 
-  if (pass == 2)
-    return;
+	if (pass == 2)
+		return;
 
-  for (i = 0; i < total_global; i++)
-    if (!strcmp(name, id_list[i].name))
-    {
-      error_message(14);
-      return;
-    }
+	for (i = 0; i < total_global; i++)
+		if (!strcmp(name, id_list[i].name))
+		{
+			error_message(14);
+			return;
+		}
 
-  if (++total_global == MAX_ID)
-    error_message(11);
+	if (++total_global == MAX_ID)
+		error_message(11);
 
-  id_list[total_global - 1].name = malloc(strlen(name) + 1);
+	id_list[total_global - 1].name = malloc(strlen(name) + 1);
 
-  /* guarantees we won't pass string literal to strtok(), which causes SEGFAULT on GCC 6.2.0 */
-  _name = strdup(name);
-  if (!_name)
-  {
-    fprintf(stderr, "Error: can't allocate memory with strdup() in %s\n", __func__);
-    exit(1);
-  }
+	/* guarantees we won't pass string literal to strtok(), which causes SEGFAULT on GCC 6.2.0 */
+	_name = strdup(name);
+	if (!_name)
+	{
+		fprintf(stderr, "Error: can't allocate memory with strdup() in %s\n", __func__);
+		exit(1);
+	}
 
-  strcpy(id_list[total_global - 1].name, strtok(_name, " "));
-  free(_name);
+	strcpy(id_list[total_global - 1].name, strtok(_name, " "));
+	free(_name);
 
-  id_list[total_global - 1].value = n;
-  id_list[total_global - 1].type = rom_type;
+	id_list[total_global - 1].value = n;
+	id_list[total_global - 1].type = rom_type;
 }
 
 void register_variable(char *name, int n)
 {
-  int i;
+	int i;
 
-  for (i = 0; i < total_global; i++)
-    if ((!strcmp(name, id_list[i].name)) && (id_list[i].type == 3))
-    {
-      id_list[i].value = n;
-      return;
-    }
+	for (i = 0; i < total_global; i++)
+		if ((!strcmp(name, id_list[i].name)) && (id_list[i].type == 3))
+		{
+			id_list[i].value = n;
+			return;
+		}
 
-  if (++total_global == MAX_ID)
-    error_message(11);
+	if (++total_global == MAX_ID)
+		error_message(11);
 
-  id_list[total_global - 1].name = malloc(strlen(name) + 1);
-  strcpy(id_list[total_global - 1].name, strtok(name, " "));
-  id_list[total_global - 1].value = n;
-  id_list[total_global - 1].type = 3;
+	id_list[total_global - 1].name = malloc(strlen(name) + 1);
+	strcpy(id_list[total_global - 1].name, strtok(name, " "));
+	id_list[total_global - 1].value = n;
+	id_list[total_global - 1].type = 3;
 }
 
 int read_label(char *name)
 {
-  int i;
+	int i;
 
-  for (i = 0; i < total_global; i++)
-    if (!strcmp(name, id_list[i].name))
-      return id_list[i].value;
+	for (i = 0; i < total_global; i++)
+		if (!strcmp(name, id_list[i].name))
+			return id_list[i].value;
 
-  if ((pass == 1) && (i == total_global))
-    return ePC;
+	if ((pass == 1) && (i == total_global))
+		return ePC;
 
-  error_message(12);
-  exit(0);	/* error_message() never returns; add exit() to stop compiler warnings about bad return value */
+	error_message(12);
+	exit(0);	/* error_message() never returns; add exit() to stop compiler warnings about bad return value */
 }
 
 int read_local(char *name)
 {
-  int i;
+	int i;
 
-  if (pass == 1)
-    return ePC;
+	if (pass == 1)
+		return ePC;
 
-  for (i = last_global; i < total_global; i++)
-    if (!strcmp(name, id_list[i].name))
-      return id_list[i].value;
+	for (i = last_global; i < total_global; i++)
+		if (!strcmp(name, id_list[i].name))
+			return id_list[i].value;
 
-  error_message(13);
-  exit(0);	/* error_message() never returns; add exit() to stop compiler warnings about bad return value */
+	error_message(13);
+	exit(0);	/* error_message() never returns; add exit() to stop compiler warnings about bad return value */
 }
 
 void create_txt()
 {
-  /* Generate the name of output text file */
-  strncpy(fname_txt, fname_no_ext, PATH_MAX);
-  fname_txt = strncat(fname_txt, ".txt", PATH_MAX);
-  fmsg = fopen(fname_txt, "wt");
-  if (fmsg == NULL)
-    return;
+	/* Generate the name of output text file */
+	strncpy(fname_txt, fname_no_ext, PATH_MAX);
+	fname_txt = strncat(fname_txt, ".txt", PATH_MAX);
+	fmsg = fopen(fname_txt, "wt");
+	if (fmsg == NULL)
+		return;
 
-  fprintf(fmsg, "; Output text file from %s\n", fname_asm);
-  fprintf(fmsg, "; generated by asMSX v.%s\n\n", VERSION);
-  printf("Output text file %s saved\n", fname_txt);
+	fprintf(fmsg, "; Output text file from %s\n", fname_asm);
+	fprintf(fmsg, "; generated by asMSX v.%s\n\n", VERSION);
+	printf("Output text file %s saved\n", fname_txt);
 }
 
 void write_sym()
 {
-  int i, j;
-  FILE *f;
+	int i, j;
+	FILE *f;
 
-  j = 0;
-  for (i = 0; i < total_global; i++)
-    j += id_list[i].type;
+	j = 0;
+	for (i = 0; i < total_global; i++)
+		j += id_list[i].type;
 
-  if (j > 0)
-  {
-    if ((f = fopen(fname_sym, "wt")) == NULL)
+	if (j > 0)
 	{
-      error_message(0);
-	  exit(1); /* this is unreachable due to error_message() never returning; use it to prevent code analyzer warning */
+		if ((f = fopen(fname_sym, "wt")) == NULL)
+		{
+			error_message(0);
+			exit(1); /* this is unreachable due to error_message() never returning; use it to prevent code analyzer warning */
+		}
+
+		fprintf(f, "; Symbol table from %s\n", fname_asm);
+		fprintf(f, "; generated by asMSX v.%s\n\n", VERSION);
+
+		j = 0;
+		for (i = 0; i < total_global; i++)
+			if (id_list[i].type == 1)
+				j++;
+		if (j > 0)
+		{
+			fprintf(f, "; global and local labels\n");
+			for (i = 0; i < total_global; i++)
+				if (id_list[i].type == 1)
+				{
+					if (rom_type != MEGAROM)
+						fprintf(f, "%4.4Xh %s\n", id_list[i].value, id_list[i].name);
+					else
+						fprintf(f, "%2.2Xh:%4.4Xh %s\n", id_list[i].page & 0xff, id_list[i].value, id_list[i].name);
+				}
+		}
+
+		j = 0;
+		for (i = 0; i < total_global; i++)
+			if (id_list[i].type == 2)
+				j++;
+		if (j > 0)
+		{
+			fprintf(f, "; other identifiers\n");
+			for (i = 0; i < total_global; i++)
+				if (id_list[i].type == 2)
+					fprintf(f, "%4.4Xh %s\n", id_list[i].value, id_list[i].name);
+		}
+
+		j = 0;
+		for (i = 0; i < total_global; i++)
+			if (id_list[i].type == 3)
+				j++;
+		if (j > 0)
+		{
+			fprintf(f, "; variables - value on exit\n");
+			for (i = 0; i < total_global; i++)
+				if (id_list[i].type == 3)
+					fprintf(f, "%4.4Xh %s\n", id_list[i].value, id_list[i].name);
+		}
+
+		fclose(f);
+		printf("Symbol file %s saved\n", fname_sym);
 	}
-
-    fprintf(f, "; Symbol table from %s\n", fname_asm);
-    fprintf(f, "; generated by asMSX v.%s\n\n", VERSION);
-
-    j = 0;
-    for (i = 0; i < total_global; i++)
-      if (id_list[i].type == 1)
-        j++;
-    if (j > 0)
-    {
-      fprintf(f, "; global and local labels\n");
-      for (i = 0; i < total_global; i++)
-        if (id_list[i].type == 1)
-        {
-          if (rom_type != MEGAROM)
-            fprintf(f, "%4.4Xh %s\n", id_list[i].value, id_list[i].name);
-          else
-            fprintf(f, "%2.2Xh:%4.4Xh %s\n", id_list[i].page & 0xff, id_list[i].value, id_list[i].name);
-        }
-    }
-
-    j = 0;
-    for (i = 0; i < total_global; i++)
-      if (id_list[i].type == 2)
-        j++;
-    if (j > 0)
-    {
-      fprintf(f, "; other identifiers\n");
-      for (i = 0; i < total_global; i++)
-        if (id_list[i].type == 2)
-          fprintf(f, "%4.4Xh %s\n", id_list[i].value, id_list[i].name);
-    }
-
-    j = 0;
-    for (i = 0; i < total_global; i++)
-      if (id_list[i].type == 3)
-        j++;
-    if (j > 0)
-    {
-      fprintf(f, "; variables - value on exit\n");
-      for (i = 0; i < total_global; i++)
-        if (id_list[i].type == 3)
-          fprintf(f, "%4.4Xh %s\n", id_list[i].value, id_list[i].name);
-    }
-
-    fclose(f);
-    printf("Symbol file %s saved\n", fname_sym);
-  }
 }
 
 void yyerror(char *s)
 {
-  /* print bison error message */
-  fprintf(stderr, "Parsing error: %s\n", s);
-  error_message(0);
+	/* print bison error message */
+	fprintf(stderr, "Parsing error: %s\n", s);
+	error_message(0);
 }
 
 void include_binary(char *fname, int skip, int n)
 {
-  FILE *f;
-  int k;
-  int i;
+	FILE *f;
+	int k;
+	int i;
 
-  if ((f = fopen(fname, "rb")) == NULL)
-    error_message(18);
+	if ((f = fopen(fname, "rb")) == NULL)
+		error_message(18);
 
-  if (pass == 1)
-    printf("Including binary file %s", fname);
+	if (pass == 1)
+		printf("Including binary file %s", fname);
 
-  if ((pass == 1) && skip)
-    printf(", skipping %i bytes", skip);
+	if ((pass == 1) && skip)
+		printf(", skipping %i bytes", skip);
 
-  if ((pass == 1) && n)
-    printf(", saving %i bytes", n);
+	if ((pass == 1) && n)
+		printf(", saving %i bytes", n);
 
-  if (pass == 1)
-    printf("\n");
+	if (pass == 1)
+		printf("\n");
  
-  if (skip)
-    for (i = 0; (!feof(f)) && (i < skip); i++)
-      k = fgetc(f);
+	if (skip)
+		for (i = 0; (!feof(f)) && (i < skip); i++)
+			k = fgetc(f);
  
-  if (skip && feof(f))
-    error_message(29);
+	if (skip && feof(f))
+		error_message(29);
  
-  if (n)
-  {
-    for (i = 0; (i < n) && (!feof(f));)
-    {
-      k = fgetc(f);
-      if (!feof(f))
-      {
-        write_byte(k);
-        i++;
-      }
-    }
-    if (i < n)
-      error_message(29);
-  }
-  else
-    for (; !feof(f);)		/* TODO: rewrite this as while loop and test it */
-    {
-      k = fgetc(f);
-      if (!feof(f))		/* TODO: can this lose the last byte from included file? */
-        write_byte(k);
-    }
+	if (n)
+	{
+		for (i = 0; (i < n) && (!feof(f));)
+		{
+			k = fgetc(f);
+			if (!feof(f))
+			{
+				write_byte(k);
+				i++;
+			}
+		}
+		if (i < n)
+			error_message(29);
+	}
+	else
+		for (; !feof(f);)		/* TODO: rewrite this as while loop and test it */
+		{
+			k = fgetc(f);
+			if (!feof(f))		/* TODO: can this lose the last byte from included file? */
+				write_byte(k);
+		}
 
-  fclose(f);
+	fclose(f);
 }
-
 
 void write_zx_byte(int c)
 {
-  int k;
-  k = c & 0xff;
-  putc(k, fbin);
-  parity ^= k;
+	int k;
+	k = c & 0xff;
+	putc(k, fbin);
+	parity ^= k;
 }
 
 void write_zx_word(int c)
 {
-  write_zx_byte(c & 0xff);
-  write_zx_byte((c >> 8) & 0xff);
+	write_zx_byte(c & 0xff);
+	write_zx_byte((c >> 8) & 0xff);
 }
 
 void write_zx_number(int i)
 {
-  int c;
+	int c;
 
-  c = i / 10000;
-  i -= c * 10000;
-  write_zx_byte(c + 48);
+	c = i / 10000;
+	i -= c * 10000;
+	write_zx_byte(c + 48);
 
-  c = i / 1000;
-  i -= c * 1000;
-  write_zx_byte(c + 48);
+	c = i / 1000;
+	i -= c * 1000;
+	write_zx_byte(c + 48);
 
-  c = i / 100;
-  i -= c * 100;
-  write_zx_byte(c + 48);
+	c = i / 100;
+	i -= c * 100;
+	write_zx_byte(c + 48);
 
-  c = i / 10;
-  write_zx_byte(c + 48);
+	c = i / 10;
+	write_zx_byte(c + 48);
 
-  i %= 10;
-  write_zx_byte(i + 48);
+	i %= 10;
+	write_zx_byte(i + 48);
 }
 
 void write_bin()
 {
-  int i, j;
+	int i, j;
+	size_t t;
 
-  if ((start_address > end_address) && (rom_type != MEGAROM))
-    error_message(24);
+	if ((start_address > end_address) && (rom_type != MEGAROM))
+		error_message(24);
 
-  if (rom_type == Z80)
-    fname_bin = strcat(fname_bin, ".z80");
-  else if (rom_type == ROM)
-  {
-    fname_bin = strcat(fname_bin, ".rom");
-    PC = start_address + 2;
-    write_word(run_address);
-    if (!size)
-      size = 8 * ((end_address - start_address + 8191) / 8192);
-  }
-  else if (rom_type == BASIC)
-    fname_bin = strcat(fname_bin, ".bin");
-  else if (rom_type == MSXDOS)
-    fname_bin = strcat(fname_bin, ".com");
-  else if (rom_type == MEGAROM)
-  {
-    fname_bin = strcat(fname_bin, ".rom");
-    PC = 0x4002;
-    subpage = 0x00;
-    pageinit = 0x4000;
-    write_word(run_address);
-  }
-  else if (rom_type == SINCLAIR)
-    fname_bin = strcat(fname_bin, ".tap");
+	if (rom_type == Z80)
+		fname_bin = strcat(fname_bin, ".z80");
+	else if (rom_type == ROM)
+	{
+		fname_bin = strcat(fname_bin, ".rom");
+		PC = start_address + 2;
+		write_word(run_address);
+		if (!size)
+		size = 8 * ((end_address - start_address + 8191) / 8192);
+	}
+	else if (rom_type == BASIC)
+		fname_bin = strcat(fname_bin, ".bin");
+	else if (rom_type == MSXDOS)
+		fname_bin = strcat(fname_bin, ".com");
+	else if (rom_type == MEGAROM)
+	{
+		fname_bin = strcat(fname_bin, ".rom");
+		PC = 0x4002;
+		subpage = 0x00;
+		pageinit = 0x4000;
+		write_word(run_address);
+	}
+	else if (rom_type == SINCLAIR)
+		fname_bin = strcat(fname_bin, ".tap");
 
-  if (rom_type == MEGAROM)
-  {
-    for (i = 1, j = 0; i <= lastpage; i++)
-      j += usedpage[i];
-    j >>= 1;
-    if (j < lastpage)
-      fprintf(stderr, "Warning: %i out of %i megaROM pages are not defined\n", lastpage - j, lastpage);
-  }
+	if (rom_type == MEGAROM)
+	{
+		for (i = 1, j = 0; i <= lastpage; i++)
+			j += usedpage[i];
+		j >>= 1;
+		if (j < lastpage)
+		fprintf(stderr, "Warning: %i out of %i megaROM pages are not defined\n", lastpage - j, lastpage);
+	}
 
-  printf("Binary file %s saved\n", fname_bin);
-  fbin = fopen(fname_bin, "wb");
-  if (rom_type == BASIC)
-  {
-    putc(0xfe, fbin);
-    putc(start_address & 0xff, fbin);
-    putc((start_address >> 8) & 0xff, fbin);
-    putc(end_address & 0xff, fbin);
-    putc((end_address >> 8) & 0xff, fbin);
-    if (!run_address)
-      run_address = start_address;
-    putc(run_address & 0xff, fbin);
-    putc((run_address >> 8) & 0xff, fbin);
-  }
-  else if (rom_type == SINCLAIR)
-  {
-    if (run_address)
-    {
-      putc(0x13, fbin);
-      putc(0, fbin);
-      putc(0, fbin);
-      parity = 0x20;
-      write_zx_byte(0);
+	printf("Binary file %s saved\n", fname_bin);
+	fbin = fopen(fname_bin, "wb");
+	if (rom_type == BASIC)
+	{
+		putc(0xfe, fbin);
+		putc(start_address & 0xff, fbin);
+		putc((start_address >> 8) & 0xff, fbin);
+		putc(end_address & 0xff, fbin);
+		putc((end_address >> 8) & 0xff, fbin);
+		if (!run_address)
+			run_address = start_address;
+		putc(run_address & 0xff, fbin);
+		putc((run_address >> 8) & 0xff, fbin);
+	}
+	else if (rom_type == SINCLAIR)
+	{
+		if (run_address)
+		{
+			putc(0x13, fbin);
+			putc(0, fbin);
+			putc(0, fbin);
+			parity = 0x20;
+			write_zx_byte(0);
 
-      {
-        size_t t;
-        for (t = 0; t < 10; t++) 
-          if (t < strlen(fname_no_ext))
-            write_zx_byte(fname_no_ext[t]);
-          else
-            write_zx_byte(0x20);
-      }
+			for (t = 0; t < 10; t++) 
+				if (t < strlen(fname_no_ext))
+					write_zx_byte(fname_no_ext[t]);
+				else
+					write_zx_byte(0x20);
 
-      write_zx_byte(0x1e);      /* line length */
-      write_zx_byte(0);
-      write_zx_byte(0x0a);      /* 10 */
-      write_zx_byte(0);
-      write_zx_byte(0x1e);      /* line length */
-      write_zx_byte(0);
-      write_zx_byte(0x1b);
-      write_zx_byte(0x20);
-      write_zx_byte(0);
-      write_zx_byte(0xff);
-      write_zx_byte(0);
-      write_zx_byte(0x0a);
-      write_zx_byte(0x1a);
-      write_zx_byte(0);
-      write_zx_byte(0xfd);      /* CLEAR */
-      write_zx_byte(0xb0);      /* VAL */
-      write_zx_byte('\"');
-      write_zx_number(start_address - 1);
-      write_zx_byte('\"');
-      write_zx_byte(':');
-      write_zx_byte(0xef);      /* LOAD */
-      write_zx_byte('\"');
-      write_zx_byte('\"');
-      write_zx_byte(0xaf);      /* CODE */
-      write_zx_byte(':');
-      write_zx_byte(0xf9);      /* RANDOMIZE */
-      write_zx_byte(0xc0);      /* USR */
-      write_zx_byte(0xb0);      /* VAL */
-      write_zx_byte('\"');
-      write_zx_number(run_address);
-      write_zx_byte('\"');
-      write_zx_byte(0x0d);
-      write_zx_byte(parity);
-    }
+			write_zx_byte(0x1e);      /* line length */
+			write_zx_byte(0);
+			write_zx_byte(0x0a);      /* 10 */
+			write_zx_byte(0);
+			write_zx_byte(0x1e);      /* line length */
+			write_zx_byte(0);
+			write_zx_byte(0x1b);
+			write_zx_byte(0x20);
+			write_zx_byte(0);
+			write_zx_byte(0xff);
+			write_zx_byte(0);
+			write_zx_byte(0x0a);
+			write_zx_byte(0x1a);
+			write_zx_byte(0);
+			write_zx_byte(0xfd);      /* CLEAR */
+			write_zx_byte(0xb0);      /* VAL */
+			write_zx_byte('\"');
+			write_zx_number(start_address - 1);
+			write_zx_byte('\"');
+			write_zx_byte(':');
+			write_zx_byte(0xef);      /* LOAD */
+			write_zx_byte('\"');
+			write_zx_byte('\"');
+			write_zx_byte(0xaf);      /* CODE */
+			write_zx_byte(':');
+			write_zx_byte(0xf9);      /* RANDOMIZE */
+			write_zx_byte(0xc0);      /* USR */
+			write_zx_byte(0xb0);      /* VAL */
+			write_zx_byte('\"');
+			write_zx_number(run_address);
+			write_zx_byte('\"');
+			write_zx_byte(0x0d);
+			write_zx_byte(parity);
+		}
 
-    putc(19, fbin);		/* Header len */
-    putc(0, fbin);		/* MSB of len */
-    putc(0, fbin);		/* Header is 0 */
-    parity = 0;
+		putc(19, fbin);		/* Header len */
+		putc(0, fbin);		/* MSB of len */
+		putc(0, fbin);		/* Header is 0 */
+		parity = 0;
 
-    write_zx_byte(3);		/* Filetype (Code) */
+		write_zx_byte(3);		/* Filetype (Code) */
 
-    {
-      size_t t;
-      for (t = 0; t < 10; t++) 
-        if (t < strlen(fname_no_ext))
-          write_zx_byte(fname_no_ext[t]);
-        else
-          write_zx_byte(0x20);
-    }
 
-    write_zx_word(end_address - start_address + 1);
-    write_zx_word(start_address);	/* load address */
-    write_zx_word(0);		/* offset */
-    write_zx_byte(parity);
+		for (t = 0; t < 10; t++) 
+			if (t < strlen(fname_no_ext))
+				write_zx_byte(fname_no_ext[t]);
+			else
+				write_zx_byte(0x20);
 
-    write_zx_word(end_address - start_address + 3);	/* Length of next block */
-    parity = 0;
-    write_zx_byte(255);		/* Data... */
+		write_zx_word(end_address - start_address + 1);
+		write_zx_word(start_address);	/* load address */
+		write_zx_word(0);		/* offset */
+		write_zx_byte(parity);
 
-    for (i = start_address; i <= end_address; i++)
-      write_zx_byte(rom_buf[i]);
-    write_zx_byte(parity);
-  }
+		write_zx_word(end_address - start_address + 3);	/* Length of next block */
+		parity = 0;
+		write_zx_byte(255);		/* Data... */
 
-  if (rom_type != SINCLAIR)
-  {
-    if (!size)
-    {
-      if (rom_type != MEGAROM)
-        for (i = start_address; i <= end_address; i++)
-          putc(rom_buf[i], fbin);
-      else
-        for (i = 0; i < (lastpage + 1) * pagesize * 1024; i++)
-          putc(rom_buf[i], fbin);
-    } else if (rom_type != MEGAROM)
-      for (i = start_address; i < start_address + size * 1024; i++)
-        putc(rom_buf[i], fbin);
-    else
-      for (i = 0; i < size * 1024; i++)
-        putc(rom_buf[i], fbin);
-  }
+		for (i = start_address; i <= end_address; i++)
+			write_zx_byte(rom_buf[i]);
+		write_zx_byte(parity);
+	}
 
-  fclose(fbin);
+	if (rom_type != SINCLAIR)
+	{
+		if (!size)
+		{
+			if (rom_type != MEGAROM)
+				for (i = start_address; i <= end_address; i++)
+					putc(rom_buf[i], fbin);
+			else
+				for (i = 0; i < (lastpage + 1) * pagesize * 1024; i++)
+					putc(rom_buf[i], fbin);
+		}
+		else if (rom_type != MEGAROM)
+			for (i = start_address; i < start_address + size * 1024; i++)
+				putc(rom_buf[i], fbin);
+		else
+			for (i = 0; i < size * 1024; i++)
+				putc(rom_buf[i], fbin);
+	}
+
+	fclose(fbin);
 }
 
 void finalize()
 {
-  /* Generate the name of file with symbolic information */
-  strncpy(fname_sym, fname_no_ext, PATH_MAX);
-  fname_sym = strcat(fname_sym, ".sym");
+	/* Generate the name of file with symbolic information */
+	strncpy(fname_sym, fname_no_ext, PATH_MAX);
+	fname_sym = strcat(fname_sym, ".sym");
  
-  write_bin();
+	write_bin();
 
-  if (cassette & 3)
-	write_tape(cassette, fname_no_ext, fname_msx, rom_type,
-		start_address, end_address, run_address, rom_buf);
+	if (cassette & 3)
+		write_tape(cassette, fname_no_ext, fname_msx, rom_type,
+			start_address, end_address, run_address, rom_buf);
 
-  if (total_global > 0)
-    write_sym();
+	if (total_global > 0)
+		write_sym();
 
-  printf("Completed in %.2f seconds", (float)clock() / (float)CLOCKS_PER_SEC);
+	printf("Completed in %.2f seconds", (float)clock() / (float)CLOCKS_PER_SEC);
 
-  if (warnings > 1)
-    fprintf(stderr, ", %i warnings\n", warnings);
-  else if (warnings == 1)
-    fprintf(stderr, ", 1 warning\n");
-  else
-    printf("\n");
+	if (warnings > 1)
+		fprintf(stderr, ", %i warnings\n", warnings);
+	else if (warnings == 1)
+		fprintf(stderr, ", 1 warning\n");
+	else
+		printf("\n");
 
-  remove("~tmppre.*");
-  exit(0);
-}
-
-void initialize_memory()
-{
-  const size_t rom_buf_size = 0x1000000;	/* 16 megabytes */
-
-  rom_buf = malloc(rom_buf_size);
-  if (!rom_buf)
-  {
-    fprintf(stderr, "Failed to allocate %lu bytes for pointer 'rom_buf' in function '%s'\n", (unsigned long)rom_buf_size, __func__);
-    exit(1);
-  }
-
-  memset(rom_buf, 0, rom_buf_size);
-}
-
-void initialize_system()
-{
-  initialize_memory();
-  fname_msx = malloc(PATH_MAX + 1);
-  fname_msx[0] = 0;
-  register_symbol("Eduardo_A_Robsy_Petrus_2007", 0, 0);
+	remove("~tmppre.*");
+	exit(0);
 }
 
 void type_sinclair()
 {
-  if ((rom_type) && (rom_type != SINCLAIR))
-    error_message(46);
-  rom_type = SINCLAIR;
-  if (!start_address)
-  {
-    PC = 0x8000;
-    ePC = PC;
-  }
+	if ((rom_type) && (rom_type != SINCLAIR))
+		error_message(46);
+	rom_type = SINCLAIR;
+	if (!start_address)
+	{
+		PC = 0x8000;
+		ePC = PC;
+	}
 }
 
 void type_rom()
 {
-  if ((pass == 1) && (!start_address))
-    error_message(19);
+	if ((pass == 1) && (!start_address))
+		error_message(19);
 
-  if ((rom_type) && (rom_type != ROM))
-    error_message(20);
+	if ((rom_type) && (rom_type != ROM))
+		error_message(20);
 
-  rom_type = ROM;
-  write_byte(65);
-  write_byte(66);
-  PC += 14;
-  ePC += 14;
-  if (!run_address)
-    run_address = ePC;
+	rom_type = ROM;
+	write_byte(65);
+	write_byte(66);
+	PC += 14;
+	ePC += 14;
+	if (!run_address)
+		run_address = ePC;
 }
 
 void type_megarom(int n)
 {
-  int i;
+	int i;
 
-  if (pass == 1)
-    for (i = 0; i < 256; i++)
-      usedpage[i] = 0;
+	if (pass == 1)
+		for (i = 0; i < 256; i++)
+			usedpage[i] = 0;
 
-  if ((pass == 1) && (!start_address))
-    error_message(19);
+	if ((pass == 1) && (!start_address))
+		error_message(19);
 /* 
-  if ((pass == 1) && ((!PC) || (!ePC)))
-    error_message(19); 
+	if ((pass == 1) && ((!PC) || (!ePC)))
+		error_message(19); 
 */
-  if ((rom_type) && (rom_type != MEGAROM))
-    error_message(20);
+	if ((rom_type) && (rom_type != MEGAROM))
+		error_message(20);
 
-  if ((n < 0) || (n > 3))
-    error_message(33);
+	if ((n < 0) || (n > 3))
+		error_message(33);
 
-  rom_type = MEGAROM;
+	rom_type = MEGAROM;
 
-  usedpage[0] = 1;
-  subpage = 0;
-  pageinit = 0x4000;
-  lastpage = 0;
+	usedpage[0] = 1;
+	subpage = 0;
+	pageinit = 0x4000;
+	lastpage = 0;
 
-  if ((n == 0) || (n == 1) || (n == 2))
-    pagesize = 8;
-  else
-    pagesize = 16;
+	if ((n == 0) || (n == 1) || (n == 2))
+		pagesize = 8;
+	else
+		pagesize = 16;
 
-  mapper = n;
-  PC = 0x4000;
-  ePC = 0x4000;
-  write_byte(65);
-  write_byte(66);
-  PC += 14;
-  ePC += 14;
-  if (!run_address)
-    run_address = ePC;
+	mapper = n;
+	PC = 0x4000;
+	ePC = 0x4000;
+	write_byte(65);
+	write_byte(66);
+	PC += 14;
+	ePC += 14;
+	if (!run_address)
+		run_address = ePC;
 }
 
 
 void type_basic()
 {
-  if ((pass == 1) && (!start_address))
-    error_message(21);
+	if ((pass == 1) && (!start_address))
+		error_message(21);
 
-  if ((rom_type) && (rom_type != BASIC))
-    error_message(20);
+	if ((rom_type) && (rom_type != BASIC))
+		error_message(20);
 
-  rom_type = BASIC;
+	rom_type = BASIC;
 }
 
 void type_msxdos()
 {
-  if ((pass == 1) && (!start_address))
-    error_message(23);
+	if ((pass == 1) && (!start_address))
+		error_message(23);
 
-  if ((rom_type) && (rom_type != MSXDOS))
-    error_message(20);
-  rom_type = MSXDOS;
-  PC = 0x0100;
-  ePC = 0x0100;
+	if ((rom_type) && (rom_type != MSXDOS))
+		error_message(20);
+	rom_type = MSXDOS;
+	PC = 0x0100;
+	ePC = 0x0100;
 }
 
 void create_subpage(int n, int address)
 {
-  if (n > lastpage)
-    lastpage = n;
+	if (n > lastpage)
+		lastpage = n;
 
-  if (!n)
-    error_message(32);
+	if (!n)
+		error_message(32);
 
-  if (usedpage[n] == pass)
-    error_message(37);
-  else
-    usedpage[n] = pass;
+	if (usedpage[n] == pass)
+		error_message(37);
+	else
+		usedpage[n] = pass;
 
-  if ((address < 0x4000) || (address > 0xbfff))
-    error_message(35);
+	if ((address < 0x4000) || (address > 0xbfff))
+		error_message(35);
 
-  if (n > maxpage[mapper])
-    error_message(36);
+	if (n > maxpage[mapper])
+		error_message(36);
 
-  subpage = n;
-  pageinit = (address / pagesize) * pagesize;
-  PC = pageinit;
-  ePC = PC;
+	subpage = n;
+	pageinit = (address / pagesize) * pagesize;
+	PC = pageinit;
+	ePC = PC;
 }
 
 void locate_32k()
@@ -3982,7 +3962,6 @@ int selector(int address)
 
 	return address;
 }
-
 
 void select_page_direct(int n, int address)
 {
@@ -4075,7 +4054,19 @@ int main(int argc, char *argv[])
 	}   
   
 	clock();
-	initialize_system();
+
+	rom_buf = malloc(rom_buf_size);
+	if (!rom_buf)
+	{
+		fprintf(stderr, "Failed to allocate %lu bytes for pointer 'rom_buf' in function '%s'\n", (unsigned long)rom_buf_size, __func__);
+		exit(1);
+	}
+	memset(rom_buf, 0, rom_buf_size);
+
+	fname_msx = malloc(PATH_MAX + 1);
+	fname_msx[0] = 0;
+	register_symbol("Eduardo_A_Robsy_Petrus_2007", 0, 0);
+
 	fname_asm = malloc(PATH_MAX + 1);
 	fname_src = malloc(PATH_MAX + 1);
 	fname_p2 = malloc(PATH_MAX + 1);

--- a/src/dura.y
+++ b/src/dura.y
@@ -380,7 +380,7 @@ line:	pseudo_instruction EOL
 	| mnemo_call EOL
 	| PREPRO_FILE TEXT EOL
 	{
-		strncpy(fname_src, $2, PATH_MAX);
+		strncpy(fname_src, $2, PATH_MAX - 1);
 	}
 	| PREPRO_LINE value EOL
 	{
@@ -783,7 +783,7 @@ pseudo_instruction: PSEUDO_ORG value
 		if (conditional[conditional_level])
 		{
 			if (!fname_msx[0])
-				strncpy(fname_msx, $2, PATH_MAX);
+				strncpy(fname_msx, $2, PATH_MAX - 1);
 			cassette |= $1;
 		}
 	}
@@ -793,7 +793,7 @@ pseudo_instruction: PSEUDO_ORG value
 		{
 			if (!fname_msx[0])
 			{
-				strncpy(fname_msx, fname_bin, PATH_MAX);
+				strncpy(fname_msx, fname_bin, PATH_MAX - 1);
 				fname_msx[strlen(fname_msx) - 1] = 0;
 			}
 			cassette |= $1;
@@ -805,7 +805,7 @@ pseudo_instruction: PSEUDO_ORG value
 	}
 	| PSEUDO_FILENAME TEXT
 	{
-		strncpy(fname_no_ext, $2, PATH_MAX);
+		strncpy(fname_no_ext, $2, PATH_MAX - 1);
 	}
 ;
 
@@ -3914,8 +3914,8 @@ int read_local(char *name)
 void create_txt()
 {
 	/* Generate the name of output text file */
-	strncpy(fname_txt, fname_no_ext, PATH_MAX);
-	fname_txt = strncat(fname_txt, ".txt", PATH_MAX);
+	strncpy(fname_txt, fname_no_ext, PATH_MAX - 1);
+	fname_txt = strncat(fname_txt, ".txt", PATH_MAX - 1);
 	fmsg = fopen(fname_txt, "wt");
 	if (fmsg == NULL)
 		return;
@@ -4248,7 +4248,7 @@ void write_bin()
 void finalize()
 {
 	/* Generate the name of file with symbolic information */
-	strncpy(fname_sym, fname_no_ext, PATH_MAX);
+	strncpy(fname_sym, fname_no_ext, PATH_MAX - 1);
 	fname_sym = strcat(fname_sym, ".sym");
  
 	write_bin();
@@ -4519,17 +4519,17 @@ int main(int argc, char *argv[])
 	}
 	memset(rom_buf, 0, rom_buf_size);
 
-	fname_msx = malloc(PATH_MAX + 1);
+	fname_msx = malloc(PATH_MAX);
 	fname_msx[0] = 0;
 	register_symbol("Eduardo_A_Robsy_Petrus_2007", 0, 0);
 
-	fname_asm = malloc(PATH_MAX + 1);
-	fname_src = malloc(PATH_MAX + 1);
-	fname_p2 = malloc(PATH_MAX + 1);
-	fname_bin = malloc(PATH_MAX + 1);
-	fname_sym = malloc(PATH_MAX + 1);
-	fname_txt = malloc(PATH_MAX + 1);
-	fname_no_ext = malloc(PATH_MAX + 1);
+	fname_asm = malloc(PATH_MAX);
+	fname_src = malloc(PATH_MAX);
+	fname_p2 = malloc(PATH_MAX);
+	fname_bin = malloc(PATH_MAX);
+	fname_sym = malloc(PATH_MAX);
+	fname_txt = malloc(PATH_MAX);
+	fname_no_ext = malloc(PATH_MAX);
 	if (!fname_no_ext)
 	{
 		fprintf(stderr, "Error: can't allocate memory for fname_no_ext\n");
@@ -4551,7 +4551,7 @@ int main(int argc, char *argv[])
 
 	preprocessor1(fname_asm);
 	preprocessor3(zilog);
-	snprintf(fname_p2, PATH_MAX, "~tmppre.%i", preprocessor2());
+	snprintf(fname_p2, PATH_MAX - 1, "~tmppre.%i", preprocessor2());
 	printf("Assembling source file %s\n", fname_asm);
 
 	conditional[0] = 1;

--- a/src/dura.y
+++ b/src/dura.y
@@ -1144,1881 +1144,2243 @@ mnemo_load16bit: MNEMO_LD REGISTER_PAIR ',' value_16bits
 	}
 ;
 
-mnemo_exchange: MNEMO_EX REGISTER_PAIR ',' REGISTER_PAIR {
-      if ((($2 != 1) || ($4 != 2)) && (($2 != 2) || ($4 != 1)))
-        error_message(2);
-      if (zilog && ($2 != 1))
-        warning_message(5);
-      write_byte(0xeb);
-    }
-  | MNEMO_EX REGISTER_AF ',' REGISTER_AF APOSTROPHE {
-      write_byte(0x08);
-    }
-  | MNEMO_EXX {
-      write_byte(0xd9);
-    }
-  | MNEMO_EX REGISTER_IND_SP ',' REGISTER_PAIR {
-      if ($4 != 2)
-        error_message(2);
-      write_byte(0xe3);
-    }
-  | MNEMO_EX REGISTER_IND_SP ',' REGISTER_16_IX {
-      write_byte(0xdd);
-      write_byte(0xe3);
-    }
-  | MNEMO_EX REGISTER_IND_SP ',' REGISTER_16_IY {
-      write_byte(0xfd);
-      write_byte(0xe3);
-    }
-  | MNEMO_LDI {
-      write_byte(0xed);
-      write_byte(0xa0);
-    }
-  | MNEMO_LDIR {
-      write_byte(0xed);
-      write_byte(0xb0);
-    }
-  | MNEMO_LDD {
-      write_byte(0xed);
-      write_byte(0xa8);
-    }
-  | MNEMO_LDDR {
-      write_byte(0xed);
-      write_byte(0xb8);
-    }
-  | MNEMO_CPI {
-      write_byte(0xed);
-      write_byte(0xa1);
-    }
-  | MNEMO_CPIR {
-      write_byte(0xed);
-      write_byte(0xb1);
-    }
-  | MNEMO_CPD {
-      write_byte(0xed);
-      write_byte(0xa9);
-    }
-  | MNEMO_CPDR {
-      write_byte(0xed);
-      write_byte(0xb9);
-    }
+mnemo_exchange: MNEMO_EX REGISTER_PAIR ',' REGISTER_PAIR
+	{
+		if ((($2 != 1) || ($4 != 2)) && (($2 != 2) || ($4 != 1)))
+			error_message(2);
+		if (zilog && ($2 != 1))
+			warning_message(5);
+		write_byte(0xeb);
+	}
+	| MNEMO_EX REGISTER_AF ',' REGISTER_AF APOSTROPHE
+	{
+		write_byte(0x08);
+	}
+	| MNEMO_EXX
+	{
+		write_byte(0xd9);
+	}
+	| MNEMO_EX REGISTER_IND_SP ',' REGISTER_PAIR
+	{
+		if ($4 != 2)
+			error_message(2);
+		write_byte(0xe3);
+	}
+	| MNEMO_EX REGISTER_IND_SP ',' REGISTER_16_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xe3);
+	}
+	| MNEMO_EX REGISTER_IND_SP ',' REGISTER_16_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xe3);
+	}
+	| MNEMO_LDI
+	{
+		write_byte(0xed);
+		write_byte(0xa0);
+	}
+	| MNEMO_LDIR
+	{
+		write_byte(0xed);
+		write_byte(0xb0);
+	}
+	| MNEMO_LDD
+	{
+		write_byte(0xed);
+		write_byte(0xa8);
+	}
+	| MNEMO_LDDR
+	{
+		write_byte(0xed);
+		write_byte(0xb8);
+	}
+	| MNEMO_CPI
+	{
+		write_byte(0xed);
+		write_byte(0xa1);
+	}
+	| MNEMO_CPIR
+	{
+		write_byte(0xed);
+		write_byte(0xb1);
+	}
+	| MNEMO_CPD
+	{
+		write_byte(0xed);
+		write_byte(0xa9);
+	}
+	| MNEMO_CPDR
+	{
+		write_byte(0xed);
+		write_byte(0xb9);
+	}
 ;
 
-mnemo_math8bit: MNEMO_ADD REGISTER ',' REGISTER {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0x80|$4);
-    }
-  | MNEMO_ADD REGISTER ',' REGISTER_IX {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0xdd);
-      write_byte(0x80 | $4);
-    }
-  | MNEMO_ADD REGISTER ',' REGISTER_IY {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0xfd);
-      write_byte(0x80 | $4);
-    }
-  | MNEMO_ADD REGISTER ',' value_8bits {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0xc6);
-      write_byte($4);
-    }
-  | MNEMO_ADD REGISTER ',' REGISTER_IND_HL {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0x86);
-    }
-  | MNEMO_ADD REGISTER ',' indirect_IX {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0xdd);
-      write_byte(0x86);
-      write_byte($4);
-    }
-  | MNEMO_ADD REGISTER ',' indirect_IY {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0xfd);
-      write_byte(0x86);
-      write_byte($4);
-    }
-  | MNEMO_ADC REGISTER ',' REGISTER {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0x88 | $4);
-    }
-  | MNEMO_ADC REGISTER ',' REGISTER_IX {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0xdd);
-      write_byte(0x88 | $4);
-    }
-  | MNEMO_ADC REGISTER ',' REGISTER_IY {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0xfd);
-      write_byte(0x88 | $4);
-    }
-  | MNEMO_ADC REGISTER ',' value_8bits {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0xce);
-      write_byte($4);
-    }
-  | MNEMO_ADC REGISTER ',' REGISTER_IND_HL {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0x8e);
-    }
-  | MNEMO_ADC REGISTER ',' indirect_IX {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0xdd);
-      write_byte(0x8e);
-      write_byte($4);
-    }
-  | MNEMO_ADC REGISTER ',' indirect_IY {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0xfd);
-      write_byte(0x8e);
-      write_byte($4);
-    }
-  | MNEMO_SUB REGISTER ',' REGISTER {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0x90 | $4);
-    }
-  | MNEMO_SUB REGISTER ',' REGISTER_IX {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdd);
-      write_byte(0x90 | $4);
-    }
-  | MNEMO_SUB REGISTER ',' REGISTER_IY {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xfd);
-      write_byte(0x90 | $4);
-    }
-  | MNEMO_SUB REGISTER ',' value_8bits {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xd6);
-      write_byte($4);
-    }
-  | MNEMO_SUB REGISTER ',' REGISTER_IND_HL {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0x96);
-    }
-  | MNEMO_SUB REGISTER ',' indirect_IX {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdd);
-      write_byte(0x96);
-      write_byte($4);
-    }
-  | MNEMO_SUB REGISTER ',' indirect_IY {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xfd);
-      write_byte(0x96);
-      write_byte($4);
-    }
-  | MNEMO_SBC REGISTER ',' REGISTER {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0x98 | $4);
-    }
-  | MNEMO_SBC REGISTER ',' REGISTER_IX {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0xdd);
-      write_byte(0x98 | $4);
-    }
-  | MNEMO_SBC REGISTER ',' REGISTER_IY {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0xfd);
-      write_byte(0x98 | $4);
-    }
-  | MNEMO_SBC REGISTER ',' value_8bits {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0xde);
-      write_byte($4);
-    }
-  | MNEMO_SBC REGISTER ',' REGISTER_IND_HL {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0x9e);
-    }
-  | MNEMO_SBC REGISTER ',' indirect_IX {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0xdd);
-      write_byte(0x9e);
-      write_byte($4);
-    }
-  | MNEMO_SBC REGISTER ',' indirect_IY {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0xfd);
-      write_byte(0x9e);
-      write_byte($4);
-    }
-  | MNEMO_AND REGISTER ',' REGISTER {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xa0 | $4);
-    }
-  | MNEMO_AND REGISTER ',' REGISTER_IX {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdd);
-      write_byte(0xa0 | $4);
-    }
-  | MNEMO_AND REGISTER ',' REGISTER_IY {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xfd);
-      write_byte(0xa0 | $4);
-    }
-  | MNEMO_AND REGISTER ',' value_8bits {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xe6);
-      write_byte($4);
-    }
-  | MNEMO_AND REGISTER ',' REGISTER_IND_HL {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xa6);
-    }
-  | MNEMO_AND REGISTER ',' indirect_IX {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdd);
-      write_byte(0xa6);
-      write_byte($4);
-    }
-  | MNEMO_AND REGISTER ',' indirect_IY {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xfd);
-      write_byte(0xa6);
-      write_byte($4);
-    }
-  | MNEMO_OR REGISTER ',' REGISTER {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xb0 | $4);
-    }
-  | MNEMO_OR REGISTER ',' REGISTER_IX {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog) 
-        warning_message(5);
-      write_byte(0xdd);
-      write_byte(0xb0 | $4);
-    }
-  | MNEMO_OR REGISTER ',' REGISTER_IY {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xfd);
-      write_byte(0xb0 | $4);
-    }
-  | MNEMO_OR REGISTER ',' value_8bits {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xf6);
-      write_byte($4);
-    }
-  | MNEMO_OR REGISTER ',' REGISTER_IND_HL {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xb6);
-    }
-  | MNEMO_OR REGISTER ',' indirect_IX {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdd);
-      write_byte(0xb6);
-      write_byte($4);
-    }
-  | MNEMO_OR REGISTER ',' indirect_IY {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xfd);
-      write_byte(0xb6);
-      write_byte($4);
-    }
-  | MNEMO_XOR REGISTER ',' REGISTER {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xa8 | $4);
-    }
-  | MNEMO_XOR REGISTER ',' REGISTER_IX {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdd);
-      write_byte(0xa8 | $4);
-    }
-  | MNEMO_XOR REGISTER ',' REGISTER_IY {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xfd);
-      write_byte(0xa8 | $4);
-    }
-  | MNEMO_XOR REGISTER ',' value_8bits {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xee);
-      write_byte($4);
-    }
-  | MNEMO_XOR REGISTER ',' REGISTER_IND_HL {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xae);
-    }
-  | MNEMO_XOR REGISTER ',' indirect_IX {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdd);
-      write_byte(0xae);
-      write_byte($4);
-    }
-  | MNEMO_XOR REGISTER ',' indirect_IY {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xfd);
-      write_byte(0xae);
-      write_byte($4);
-    }
-  | MNEMO_CP REGISTER ',' REGISTER {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xb8 | $4);
-    }
-  | MNEMO_CP REGISTER ',' REGISTER_IX {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-        write_byte(0xdd);
-        write_byte(0xb8 | $4);
-    }
-  | MNEMO_CP REGISTER ',' REGISTER_IY {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xfd);
-      write_byte(0xb8 | $4);
-    }
-  | MNEMO_CP REGISTER ',' value_8bits {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xfe);
-      write_byte($4);
-    }
-  | MNEMO_CP REGISTER ',' REGISTER_IND_HL {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xbe);
-    }
-  | MNEMO_CP REGISTER ',' indirect_IX {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdd);
-      write_byte(0xbe);
-      write_byte($4);
-    }
-  | MNEMO_CP REGISTER ',' indirect_IY {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xfd);
-      write_byte(0xbe);
-      write_byte($4);
-    }
-  | MNEMO_ADD REGISTER {
-      if (zilog)
-        warning_message(5);
-      write_byte(0x80 | $2);
-    }
-  | MNEMO_ADD REGISTER_IX {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdd);
-      write_byte(0x80 | $2);
-    }
-  | MNEMO_ADD REGISTER_IY {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xfd);
-      write_byte(0x80 | $2);
-    }
-  | MNEMO_ADD value_8bits {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xc6);
-      write_byte($2);
-    }
-  | MNEMO_ADD REGISTER_IND_HL {
-      if (zilog)
-        warning_message(5);
-      write_byte(0x86);
-    }
-  | MNEMO_ADD indirect_IX {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdd);
-      write_byte(0x86);
-      write_byte($2);
-    }
-  | MNEMO_ADD indirect_IY {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xfd);
-      write_byte(0x86);
-      write_byte($2);
-    }
-  | MNEMO_ADC REGISTER {
-      if (zilog)
-        warning_message(5);
-      write_byte(0x88 | $2);
-    }
-  | MNEMO_ADC REGISTER_IX {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdd);
-      write_byte(0x88 | $2);
-    }
-  | MNEMO_ADC REGISTER_IY {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xfd);
-      write_byte(0x88|$2);
-    }
-  | MNEMO_ADC value_8bits {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xce);
-      write_byte($2);
-    }
-  | MNEMO_ADC REGISTER_IND_HL {
-      if (zilog)
-        warning_message(5);
-      write_byte(0x8e);
-    }
-  | MNEMO_ADC indirect_IX {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdd);
-      write_byte(0x8e);
-      write_byte($2);
-    }
-  | MNEMO_ADC indirect_IY {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xfd);
-      write_byte(0x8e);
-      write_byte($2);
-    }
-  | MNEMO_SUB REGISTER {
-      write_byte(0x90 | $2);
-    }
-  | MNEMO_SUB REGISTER_IX {
-      write_byte(0xdd);
-      write_byte(0x90 | $2);
-    }
-  | MNEMO_SUB REGISTER_IY {
-      write_byte(0xfd);
-      write_byte(0x90 | $2);
-    }
-  | MNEMO_SUB value_8bits {
-      write_byte(0xd6);
-      write_byte($2);
-    }
-  | MNEMO_SUB REGISTER_IND_HL {
-      write_byte(0x96);
-    }
-  | MNEMO_SUB indirect_IX {
-      write_byte(0xdd);
-      write_byte(0x96);
-      write_byte($2);
-    }
-  | MNEMO_SUB indirect_IY {
-      write_byte(0xfd);
-      write_byte(0x96);
-      write_byte($2);
-    }
-  | MNEMO_SBC REGISTER {
-      if (zilog)
-        warning_message(5);
-      write_byte(0x98 | $2);
-    }
-  | MNEMO_SBC REGISTER_IX {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdd);
-      write_byte(0x98 | $2);
-    }
-  | MNEMO_SBC REGISTER_IY {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xfd);
-      write_byte(0x98 | $2);
-    }
-  | MNEMO_SBC value_8bits {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xde);
-      write_byte($2);
-    }
-  | MNEMO_SBC REGISTER_IND_HL {
-      if (zilog)
-        warning_message(5);
-      write_byte(0x9e);
-    }
-  | MNEMO_SBC indirect_IX {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdd);
-      write_byte(0x9e);
-      write_byte($2);
-    }
-  | MNEMO_SBC indirect_IY {
-      if (zilog)
-        warning_message(5);
-        write_byte(0xfd);
-        write_byte(0x9e);
-        write_byte($2);
-    }
-  | MNEMO_AND REGISTER {
-      write_byte(0xa0 | $2);
-    }
-  | MNEMO_AND REGISTER_IX {
-      write_byte(0xdd);
-      write_byte(0xa0 | $2);
-    }
-  | MNEMO_AND REGISTER_IY {
-      write_byte(0xfd);
-      write_byte(0xa0 | $2);
-    }
-  | MNEMO_AND value_8bits {
-      write_byte(0xe6);
-      write_byte($2);
-    }
-  | MNEMO_AND REGISTER_IND_HL {
-      write_byte(0xa6);
-    }
-  | MNEMO_AND indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xa6);
-      write_byte($2);
-    }
-  | MNEMO_AND indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xa6);
-      write_byte($2);
-    }
-  | MNEMO_OR REGISTER {
-      write_byte(0xb0 | $2);
-    }
-  | MNEMO_OR REGISTER_IX {
-      write_byte(0xdd);
-      write_byte(0xb0 | $2);
-    }
-  | MNEMO_OR REGISTER_IY {
-      write_byte(0xfd);
-      write_byte(0xb0 | $2);
-    }
-  | MNEMO_OR value_8bits {
-      write_byte(0xf6);
-      write_byte($2);
-    }
-  | MNEMO_OR REGISTER_IND_HL {
-      write_byte(0xb6);
-    }
-  | MNEMO_OR indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xb6);
-      write_byte($2);
-    }
-  | MNEMO_OR indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xb6);
-      write_byte($2);
-    }
-  | MNEMO_XOR REGISTER {
-      write_byte(0xa8 | $2);
-    }
-  | MNEMO_XOR REGISTER_IX {
-      write_byte(0xdd);
-      write_byte(0xa8 | $2);
-    }
-  | MNEMO_XOR REGISTER_IY {
-      write_byte(0xfd);
-      write_byte(0xa8 | $2);
-    }
-  | MNEMO_XOR value_8bits {
-      write_byte(0xee);
-      write_byte($2);
-    }
-  | MNEMO_XOR REGISTER_IND_HL {
-      write_byte(0xae);
-    }
-  | MNEMO_XOR indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xae);
-      write_byte($2);
-    }
-  | MNEMO_XOR indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xae);
-      write_byte($2);
-    }
-  | MNEMO_CP REGISTER {
-      write_byte(0xb8 | $2);
-    }
-  | MNEMO_CP REGISTER_IX {
-      write_byte(0xdd);
-      write_byte(0xb8 | $2);
-    }
-  | MNEMO_CP REGISTER_IY {
-      write_byte(0xfd);
-      write_byte(0xb8 | $2);
-    }
-  | MNEMO_CP value_8bits {
-      write_byte(0xfe);
-      write_byte($2);
-    }
-  | MNEMO_CP REGISTER_IND_HL {
-      write_byte(0xbe);
-    }
-  | MNEMO_CP indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xbe);
-      write_byte($2);
-    }
-  | MNEMO_CP indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xbe);
-      write_byte($2);
-    }
-  | MNEMO_INC REGISTER {
-      write_byte(0x04 | ($2 << 3));
-    }
-  | MNEMO_INC REGISTER_IX {
-      write_byte(0xdd);
-      write_byte(0x04 | ($2 << 3));
-    }
-  | MNEMO_INC REGISTER_IY {
-      write_byte(0xfd);
-      write_byte(0x04 | ($2 << 3));
-    }
-  | MNEMO_INC REGISTER_IND_HL {
-      write_byte(0x34);
-    }
-  | MNEMO_INC indirect_IX {
-      write_byte(0xdd);
-      write_byte(0x34);
-      write_byte($2);
-    }
-  | MNEMO_INC indirect_IY {
-      write_byte(0xfd);
-      write_byte(0x34);
-      write_byte($2);
-    }
-  | MNEMO_DEC REGISTER {
-      write_byte(0x05 | ($2 << 3));
-    }
-  | MNEMO_DEC REGISTER_IX {
-      write_byte(0xdd);
-      write_byte(0x05 | ($2 << 3));
-    }
-  | MNEMO_DEC REGISTER_IY {
-      write_byte(0xfd);
-      write_byte(0x05 | ($2 << 3));
-    }
-  | MNEMO_DEC REGISTER_IND_HL {
-      write_byte(0x35);
-    }
-  | MNEMO_DEC indirect_IX {
-      write_byte(0xdd);
-      write_byte(0x35);
-      write_byte($2);
-    }
-  | MNEMO_DEC indirect_IY {
-      write_byte(0xfd);
-      write_byte(0x35);
-      write_byte($2);
-    }
+mnemo_math8bit: MNEMO_ADD REGISTER ',' REGISTER
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0x80|$4);
+	}
+	| MNEMO_ADD REGISTER ',' REGISTER_IX
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0xdd);
+		write_byte(0x80 | $4);
+	}
+	| MNEMO_ADD REGISTER ',' REGISTER_IY
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0xfd);
+		write_byte(0x80 | $4);
+	}
+	| MNEMO_ADD REGISTER ',' value_8bits
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0xc6);
+		write_byte($4);
+	}
+	| MNEMO_ADD REGISTER ',' REGISTER_IND_HL
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0x86);
+	}
+	| MNEMO_ADD REGISTER ',' indirect_IX
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0xdd);
+		write_byte(0x86);
+		write_byte($4);
+	}
+	| MNEMO_ADD REGISTER ',' indirect_IY
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0xfd);
+		write_byte(0x86);
+		write_byte($4);
+	}
+	| MNEMO_ADC REGISTER ',' REGISTER
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0x88 | $4);
+	}
+	| MNEMO_ADC REGISTER ',' REGISTER_IX
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0xdd);
+		write_byte(0x88 | $4);
+	}
+	| MNEMO_ADC REGISTER ',' REGISTER_IY
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0xfd);
+		write_byte(0x88 | $4);
+	}
+	| MNEMO_ADC REGISTER ',' value_8bits
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0xce);
+		write_byte($4);
+	}
+	| MNEMO_ADC REGISTER ',' REGISTER_IND_HL
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0x8e);
+	}
+	| MNEMO_ADC REGISTER ',' indirect_IX
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0xdd);
+		write_byte(0x8e);
+		write_byte($4);
+	}
+	| MNEMO_ADC REGISTER ',' indirect_IY
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0xfd);
+		write_byte(0x8e);
+		write_byte($4);
+	}
+	| MNEMO_SUB REGISTER ',' REGISTER
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0x90 | $4);
+	}
+	| MNEMO_SUB REGISTER ',' REGISTER_IX
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdd);
+		write_byte(0x90 | $4);
+	}
+	| MNEMO_SUB REGISTER ',' REGISTER_IY
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfd);
+		write_byte(0x90 | $4);
+	}
+	| MNEMO_SUB REGISTER ',' value_8bits
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xd6);
+		write_byte($4);
+	}
+	| MNEMO_SUB REGISTER ',' REGISTER_IND_HL
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0x96);
+	}
+	| MNEMO_SUB REGISTER ',' indirect_IX
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdd);
+		write_byte(0x96);
+		write_byte($4);
+	}
+	| MNEMO_SUB REGISTER ',' indirect_IY
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfd);
+		write_byte(0x96);
+		write_byte($4);
+	}
+	| MNEMO_SBC REGISTER ',' REGISTER
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0x98 | $4);
+	}
+	| MNEMO_SBC REGISTER ',' REGISTER_IX
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0xdd);
+		write_byte(0x98 | $4);
+	}
+	| MNEMO_SBC REGISTER ',' REGISTER_IY
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0xfd);
+		write_byte(0x98 | $4);
+	}
+	| MNEMO_SBC REGISTER ',' value_8bits
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0xde);
+		write_byte($4);
+	}
+	| MNEMO_SBC REGISTER ',' REGISTER_IND_HL
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0x9e);
+	}
+	| MNEMO_SBC REGISTER ',' indirect_IX
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0xdd);
+		write_byte(0x9e);
+		write_byte($4);
+	}
+	| MNEMO_SBC REGISTER ',' indirect_IY
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0xfd);
+		write_byte(0x9e);
+		write_byte($4);
+	}
+	| MNEMO_AND REGISTER ',' REGISTER
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xa0 | $4);
+	}
+	| MNEMO_AND REGISTER ',' REGISTER_IX
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdd);
+		write_byte(0xa0 | $4);
+	}
+	| MNEMO_AND REGISTER ',' REGISTER_IY
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfd);
+		write_byte(0xa0 | $4);
+	}
+	| MNEMO_AND REGISTER ',' value_8bits
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xe6);
+		write_byte($4);
+	}
+	| MNEMO_AND REGISTER ',' REGISTER_IND_HL
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xa6);
+	}
+	| MNEMO_AND REGISTER ',' indirect_IX
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdd);
+		write_byte(0xa6);
+		write_byte($4);
+	}
+	| MNEMO_AND REGISTER ',' indirect_IY
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfd);
+		write_byte(0xa6);
+		write_byte($4);
+	}
+	| MNEMO_OR REGISTER ',' REGISTER
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xb0 | $4);
+	}
+	| MNEMO_OR REGISTER ',' REGISTER_IX
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog) 
+			warning_message(5);
+		write_byte(0xdd);
+		write_byte(0xb0 | $4);
+	}
+	| MNEMO_OR REGISTER ',' REGISTER_IY
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfd);
+		write_byte(0xb0 | $4);
+	}
+	| MNEMO_OR REGISTER ',' value_8bits
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xf6);
+		write_byte($4);
+	}
+	| MNEMO_OR REGISTER ',' REGISTER_IND_HL
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xb6);
+	}
+	| MNEMO_OR REGISTER ',' indirect_IX
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdd);
+		write_byte(0xb6);
+		write_byte($4);
+	}
+	| MNEMO_OR REGISTER ',' indirect_IY
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfd);
+		write_byte(0xb6);
+		write_byte($4);
+	}
+	| MNEMO_XOR REGISTER ',' REGISTER
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xa8 | $4);
+	}
+	| MNEMO_XOR REGISTER ',' REGISTER_IX
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdd);
+		write_byte(0xa8 | $4);
+	}
+	| MNEMO_XOR REGISTER ',' REGISTER_IY
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfd);
+		write_byte(0xa8 | $4);
+	}
+	| MNEMO_XOR REGISTER ',' value_8bits
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xee);
+		write_byte($4);
+	}
+	| MNEMO_XOR REGISTER ',' REGISTER_IND_HL
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xae);
+	}
+	| MNEMO_XOR REGISTER ',' indirect_IX
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdd);
+		write_byte(0xae);
+		write_byte($4);
+	}
+	| MNEMO_XOR REGISTER ',' indirect_IY
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfd);
+		write_byte(0xae);
+		write_byte($4);
+	}
+	| MNEMO_CP REGISTER ',' REGISTER
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xb8 | $4);
+	}
+	| MNEMO_CP REGISTER ',' REGISTER_IX
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdd);
+		write_byte(0xb8 | $4);
+	}
+	| MNEMO_CP REGISTER ',' REGISTER_IY
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfd);
+		write_byte(0xb8 | $4);
+	}
+	| MNEMO_CP REGISTER ',' value_8bits
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfe);
+		write_byte($4);
+	}
+	| MNEMO_CP REGISTER ',' REGISTER_IND_HL
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xbe);
+	}
+	| MNEMO_CP REGISTER ',' indirect_IX
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdd);
+		write_byte(0xbe);
+		write_byte($4);
+	}
+	| MNEMO_CP REGISTER ',' indirect_IY
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfd);
+		write_byte(0xbe);
+		write_byte($4);
+	}
+	| MNEMO_ADD REGISTER
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0x80 | $2);
+	}
+	| MNEMO_ADD REGISTER_IX
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdd);
+		write_byte(0x80 | $2);
+	}
+	| MNEMO_ADD REGISTER_IY
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfd);
+		write_byte(0x80 | $2);
+	}
+	| MNEMO_ADD value_8bits
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xc6);
+		write_byte($2);
+	}
+	| MNEMO_ADD REGISTER_IND_HL
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0x86);
+	}
+	| MNEMO_ADD indirect_IX
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdd);
+		write_byte(0x86);
+		write_byte($2);
+	}
+	| MNEMO_ADD indirect_IY
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfd);
+		write_byte(0x86);
+		write_byte($2);
+	}
+	| MNEMO_ADC REGISTER
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0x88 | $2);
+	}
+	| MNEMO_ADC REGISTER_IX
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdd);
+		write_byte(0x88 | $2);
+	}
+	| MNEMO_ADC REGISTER_IY
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfd);
+		write_byte(0x88|$2);
+	}
+	| MNEMO_ADC value_8bits
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xce);
+		write_byte($2);
+	}
+	| MNEMO_ADC REGISTER_IND_HL
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0x8e);
+	}
+	| MNEMO_ADC indirect_IX
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdd);
+		write_byte(0x8e);
+		write_byte($2);
+	}
+	| MNEMO_ADC indirect_IY
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfd);
+		write_byte(0x8e);
+		write_byte($2);
+	}
+	| MNEMO_SUB REGISTER
+	{
+		write_byte(0x90 | $2);
+	}
+	| MNEMO_SUB REGISTER_IX
+	{
+		write_byte(0xdd);
+		write_byte(0x90 | $2);
+	}
+	| MNEMO_SUB REGISTER_IY
+	{
+		write_byte(0xfd);
+		write_byte(0x90 | $2);
+	}
+	| MNEMO_SUB value_8bits
+	{
+		write_byte(0xd6);
+		write_byte($2);
+	}
+	| MNEMO_SUB REGISTER_IND_HL
+	{
+		write_byte(0x96);
+	}
+	| MNEMO_SUB indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0x96);
+		write_byte($2);
+	}
+	| MNEMO_SUB indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0x96);
+		write_byte($2);
+	}
+	| MNEMO_SBC REGISTER
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0x98 | $2);
+	}
+	| MNEMO_SBC REGISTER_IX
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdd);
+		write_byte(0x98 | $2);
+	}
+	| MNEMO_SBC REGISTER_IY
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfd);
+		write_byte(0x98 | $2);
+	}
+	| MNEMO_SBC value_8bits
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xde);
+		write_byte($2);
+	}
+	| MNEMO_SBC REGISTER_IND_HL
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0x9e);
+	}
+	| MNEMO_SBC indirect_IX
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdd);
+		write_byte(0x9e);
+		write_byte($2);
+	}
+	| MNEMO_SBC indirect_IY
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xfd);
+		write_byte(0x9e);
+		write_byte($2);
+	}
+	| MNEMO_AND REGISTER
+	{
+		write_byte(0xa0 | $2);
+	}
+	| MNEMO_AND REGISTER_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xa0 | $2);
+	}
+	| MNEMO_AND REGISTER_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xa0 | $2);
+	}
+	| MNEMO_AND value_8bits
+	{
+		write_byte(0xe6);
+		write_byte($2);
+	}
+	| MNEMO_AND REGISTER_IND_HL
+	{
+		write_byte(0xa6);
+	}
+	| MNEMO_AND indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xa6);
+		write_byte($2);
+	}
+	| MNEMO_AND indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xa6);
+		write_byte($2);
+	}
+	| MNEMO_OR REGISTER
+	{
+		write_byte(0xb0 | $2);
+	}
+	| MNEMO_OR REGISTER_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xb0 | $2);
+	}
+	| MNEMO_OR REGISTER_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xb0 | $2);
+	}
+	| MNEMO_OR value_8bits
+	{
+		write_byte(0xf6);
+		write_byte($2);
+	}
+	| MNEMO_OR REGISTER_IND_HL
+	{
+		write_byte(0xb6);
+	}
+	| MNEMO_OR indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xb6);
+		write_byte($2);
+	}
+	| MNEMO_OR indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xb6);
+		write_byte($2);
+	}
+	| MNEMO_XOR REGISTER {
+		write_byte(0xa8 | $2);
+	}
+	| MNEMO_XOR REGISTER_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xa8 | $2);
+	}
+	| MNEMO_XOR REGISTER_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xa8 | $2);
+	}
+	| MNEMO_XOR value_8bits
+	{
+		write_byte(0xee);
+		write_byte($2);
+	}
+	| MNEMO_XOR REGISTER_IND_HL
+	{
+		write_byte(0xae);
+	}
+	| MNEMO_XOR indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xae);
+		write_byte($2);
+	}
+	| MNEMO_XOR indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xae);
+		write_byte($2);
+	}
+	| MNEMO_CP REGISTER
+	{
+		write_byte(0xb8 | $2);
+	}
+	| MNEMO_CP REGISTER_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xb8 | $2);
+	}
+	| MNEMO_CP REGISTER_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xb8 | $2);
+	}
+	| MNEMO_CP value_8bits
+	{
+		write_byte(0xfe);
+		write_byte($2);
+	}
+	| MNEMO_CP REGISTER_IND_HL
+	{
+		write_byte(0xbe);
+	}
+	| MNEMO_CP indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xbe);
+		write_byte($2);
+	}
+	| MNEMO_CP indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xbe);
+		write_byte($2);
+	}
+	| MNEMO_INC REGISTER
+	{
+		write_byte(0x04 | ($2 << 3));
+	}
+	| MNEMO_INC REGISTER_IX
+	{
+		write_byte(0xdd);
+		write_byte(0x04 | ($2 << 3));
+	}
+	| MNEMO_INC REGISTER_IY
+	{
+		write_byte(0xfd);
+		write_byte(0x04 | ($2 << 3));
+	}
+	| MNEMO_INC REGISTER_IND_HL
+	{
+		write_byte(0x34);
+	}
+	| MNEMO_INC indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0x34);
+		write_byte($2);
+	}
+	| MNEMO_INC indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0x34);
+		write_byte($2);
+	}
+	| MNEMO_DEC REGISTER
+	{
+		write_byte(0x05 | ($2 << 3));
+	}
+	| MNEMO_DEC REGISTER_IX
+	{
+		write_byte(0xdd);
+		write_byte(0x05 | ($2 << 3));
+	}
+	| MNEMO_DEC REGISTER_IY
+	{
+		write_byte(0xfd);
+		write_byte(0x05 | ($2 << 3));
+	}
+	| MNEMO_DEC REGISTER_IND_HL
+	{
+		write_byte(0x35);
+	}
+	| MNEMO_DEC indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0x35);
+		write_byte($2);
+	}
+	| MNEMO_DEC indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0x35);
+		write_byte($2);
+	}
 ;
 
-mnemo_math16bit: MNEMO_ADD REGISTER_PAIR ',' REGISTER_PAIR {
-      if ($2 != 2)
-        error_message(2);
-      write_byte(0x09 | ($4 << 4));
-    }
-  | MNEMO_ADC REGISTER_PAIR ',' REGISTER_PAIR {
-      if ($2 != 2)
-        error_message(2);
-      write_byte(0xed);
-      write_byte(0x4a | ($4 << 4));
-    }
-  | MNEMO_SBC REGISTER_PAIR ',' REGISTER_PAIR {
-      if ($2 != 2)
-        error_message(2);
-      write_byte(0xed);
-      write_byte(0x42 | ($4 << 4));
-    }
-  | MNEMO_ADD REGISTER_16_IX ',' REGISTER_PAIR {
-      if ($4 == 2)
-        error_message(2);
-      write_byte(0xdd);
-      write_byte(0x09 | ($4 << 4));
-    }
-  | MNEMO_ADD REGISTER_16_IX ',' REGISTER_16_IX {
-      write_byte(0xdd);
-      write_byte(0x29);
-    }
-  | MNEMO_ADD REGISTER_16_IY ',' REGISTER_PAIR {
-      if ($4 == 2)
-        error_message(2);
-      write_byte(0xfd);
-      write_byte(0x09 | ($4 << 4));
-    }
-  | MNEMO_ADD REGISTER_16_IY ',' REGISTER_16_IY {
-      write_byte(0xfd);
-      write_byte(0x29);
-    }
-  | MNEMO_INC REGISTER_PAIR {
-      write_byte(0x03 | ($2 << 4));
-    }
-  | MNEMO_INC REGISTER_16_IX {
-      write_byte(0xdd);
-      write_byte(0x23);
-    }
-  | MNEMO_INC REGISTER_16_IY {
-      write_byte(0xfd);
-      write_byte(0x23);
-    }
-  | MNEMO_DEC REGISTER_PAIR {
-      write_byte(0x0b | ($2 << 4));
-    }
-  | MNEMO_DEC REGISTER_16_IX {
-      write_byte(0xdd);
-      write_byte(0x2b);
-    }
-  | MNEMO_DEC REGISTER_16_IY {
-      write_byte(0xfd);
-      write_byte(0x2b);
-    }
+mnemo_math16bit: MNEMO_ADD REGISTER_PAIR ',' REGISTER_PAIR
+	{
+		if ($2 != 2)
+			error_message(2);
+		write_byte(0x09 | ($4 << 4));
+	}
+	| MNEMO_ADC REGISTER_PAIR ',' REGISTER_PAIR
+	{
+		if ($2 != 2)
+			error_message(2);
+		write_byte(0xed);
+		write_byte(0x4a | ($4 << 4));
+	}
+	| MNEMO_SBC REGISTER_PAIR ',' REGISTER_PAIR
+	{
+		if ($2 != 2)
+			error_message(2);
+		write_byte(0xed);
+		write_byte(0x42 | ($4 << 4));
+	}
+	| MNEMO_ADD REGISTER_16_IX ',' REGISTER_PAIR
+	{
+		if ($4 == 2)
+			error_message(2);
+		write_byte(0xdd);
+		write_byte(0x09 | ($4 << 4));
+	}
+	| MNEMO_ADD REGISTER_16_IX ',' REGISTER_16_IX
+	{
+		write_byte(0xdd);
+		write_byte(0x29);
+	}
+	| MNEMO_ADD REGISTER_16_IY ',' REGISTER_PAIR
+	{
+		if ($4 == 2)
+			error_message(2);
+		write_byte(0xfd);
+		write_byte(0x09 | ($4 << 4));
+	}
+	| MNEMO_ADD REGISTER_16_IY ',' REGISTER_16_IY
+	{
+		write_byte(0xfd);
+		write_byte(0x29);
+	}
+	| MNEMO_INC REGISTER_PAIR
+	{
+		write_byte(0x03 | ($2 << 4));
+	}
+	| MNEMO_INC REGISTER_16_IX
+	{
+		write_byte(0xdd);
+		write_byte(0x23);
+	}
+	| MNEMO_INC REGISTER_16_IY
+	{
+		write_byte(0xfd);
+		write_byte(0x23);
+	}
+	| MNEMO_DEC REGISTER_PAIR
+	{
+		write_byte(0x0b | ($2 << 4));
+	}
+	| MNEMO_DEC REGISTER_16_IX
+	{
+		write_byte(0xdd);
+		write_byte(0x2b);
+	}
+	| MNEMO_DEC REGISTER_16_IY
+	{
+		write_byte(0xfd);
+		write_byte(0x2b);
+	}
 ;
 
-mnemo_general: MNEMO_DAA {
-      write_byte(0x27);
-    }
-  | MNEMO_CPL {
-      write_byte(0x2f);
-    }
-  | MNEMO_NEG {
-      write_byte(0xed);
-      write_byte(0x44);
-    }
-  | MNEMO_CCF {
-      write_byte(0x3f);
-    }
-  | MNEMO_SCF {
-      write_byte(0x37);
-    }
-  | MNEMO_NOP {
-      write_byte(0x00);
-    }
-  | MNEMO_HALT {
-      write_byte(0x76);
-    }
-  | MNEMO_DI {
-      write_byte(0xf3);
-    }
-  | MNEMO_EI {
-      write_byte(0xfb);
-    }
-  | MNEMO_IM value_8bits {
-      if (($2 < 0) || ($2 > 2))
-        error_message(3);
-      write_byte(0xed);
-      if ($2 == 0)
-        write_byte(0x46);
-      else if ($2 == 1)
-        write_byte(0x56);
-      else
-        write_byte(0x5e);
-    }
+mnemo_general: MNEMO_DAA
+	{
+		write_byte(0x27);
+	}
+	| MNEMO_CPL
+	{
+		write_byte(0x2f);
+	}
+	| MNEMO_NEG
+	{
+		write_byte(0xed);
+		write_byte(0x44);
+	}
+	| MNEMO_CCF
+	{
+		write_byte(0x3f);
+	}
+	| MNEMO_SCF
+	{
+		write_byte(0x37);
+	}
+	| MNEMO_NOP
+	{
+		write_byte(0x00);
+	}
+	| MNEMO_HALT
+	{
+		write_byte(0x76);
+	}
+	| MNEMO_DI
+	{
+		write_byte(0xf3);
+	}
+	| MNEMO_EI
+	{
+		write_byte(0xfb);
+	}
+	| MNEMO_IM value_8bits
+	{
+		if (($2 < 0) || ($2 > 2))
+			error_message(3);
+		write_byte(0xed);
+		if ($2 == 0)
+			write_byte(0x46);
+		else if ($2 == 1)
+			write_byte(0x56);
+		else
+			write_byte(0x5e);
+	}
 ;
 
-mnemo_rotate: MNEMO_RLCA {
-      write_byte(0x07);
-    }
-  | MNEMO_RLA {
-      write_byte(0x17);
-    }
-  | MNEMO_RRCA {
-      write_byte(0x0f);
-    }
-  | MNEMO_RRA {
-      write_byte(0x1f);
-    }
-  | MNEMO_RLC REGISTER {
-      write_byte(0xcb);
-      write_byte($2);
-    }
-  | MNEMO_RLC REGISTER_IND_HL {
-      write_byte(0xcb);
-      write_byte(0x06);
-    }
-  | MNEMO_RLC indirect_IX ',' REGISTER {
-      if ($4 == 6)
-        error_message(2);
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte($4);
-    }
-  | MNEMO_RLC indirect_IY ',' REGISTER {
-      if ($4 == 6)
-        error_message(2);
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte($4);
-    }
-  | MNEMO_RLC indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte(0x06);
-    }
-  | MNEMO_RLC indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte(0x06);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_RLC indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($5);
-      write_byte($2);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_RLC indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($5);
-      write_byte($2);
-    }
-  | MNEMO_RL REGISTER {
-      write_byte(0xcb);
-      write_byte(0x10 | $2);
-    }
-  | MNEMO_RL REGISTER_IND_HL {
-      write_byte(0xcb);
-      write_byte(0x16);
-    }
-  | MNEMO_RL indirect_IX ',' REGISTER {
-      if ($4 == 6)
-        error_message(2);
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte($4 | 0x10);
-    }
-  | MNEMO_RL indirect_IY ',' REGISTER {
-      if ($4 == 6)
-        error_message(2);
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte($4 | 0x10);
-    }
-  | MNEMO_RL indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte(0x16);
-    }
-  | MNEMO_RL indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte(0x16);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_RL indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($5);
-      write_byte(0x10 | $2);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_RL indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($5);
-      write_byte(0x10 | $2);
-    }
-  | MNEMO_RRC REGISTER {
-      write_byte(0xcb);
-      write_byte(0x08 | $2);
-    }
-  | MNEMO_RRC REGISTER_IND_HL {
-      write_byte(0xcb);
-      write_byte(0x0e);
-    }
-  | MNEMO_RRC indirect_IX ',' REGISTER {
-      if ($4 == 6)
-        error_message(2);
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte($4 | 0x08);
-    }
-  | MNEMO_RRC indirect_IY ',' REGISTER {
-      if ($4 == 6)
-        error_message(2);
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte($4 | 0x08);
-    }
-  | MNEMO_RRC indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte(0x0e);
-    }
-  | MNEMO_RRC indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte(0x0e);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_RRC indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($5);
-      write_byte(0x08 | $2);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_RRC indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($5);
-      write_byte(0x08 | $2);
-    }
-  | MNEMO_RR REGISTER {
-      write_byte(0xcb);
-      write_byte(0x18 | $2);
-    }
-  | MNEMO_RR REGISTER_IND_HL {
-      write_byte(0xcb);
-      write_byte(0x1e);
-    }
-  | MNEMO_RR indirect_IX ',' REGISTER {
-      if ($4 == 6)
-        error_message(2);
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte($4 | 0x18);
-    }
-  | MNEMO_RR indirect_IY ',' REGISTER {
-      if ($4 == 6)
-        error_message(2);
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte($4 | 0x18);
-    }
-  | MNEMO_RR indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte(0x1e);
-    }
-  | MNEMO_RR indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte(0x1e);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_RR indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($5);
-      write_byte(0x18 | $2);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_RR indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($5);
-      write_byte(0x18 | $2);
-    }
-  | MNEMO_SLA REGISTER {
-      write_byte(0xcb);
-      write_byte(0x20 | $2);
-    }
-  | MNEMO_SLA REGISTER_IND_HL {
-      write_byte(0xcb);
-      write_byte(0x26);
-    } 
-  | MNEMO_SLA indirect_IX ',' REGISTER {
-      if ($4 == 6)
-        error_message(2);
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte($4 | 0x20);
-    }
-  | MNEMO_SLA indirect_IY ',' REGISTER {
-      if ($4 == 6)
-        error_message(2);
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte($4 | 0x20);
-    }
-  | MNEMO_SLA indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte(0x26);
-    }
-  | MNEMO_SLA indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte(0x26);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_SLA indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($5);
-      write_byte(0x20 | $2);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_SLA indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($5);
-      write_byte(0x20 | $2);
-    }
-  | MNEMO_SLL REGISTER {
-      write_byte(0xcb);
-      write_byte(0x30 | $2);
-    }
-  | MNEMO_SLL REGISTER_IND_HL {
-      write_byte(0xcb);
-      write_byte(0x36);
-    }
-  | MNEMO_SLL indirect_IX ',' REGISTER {
-      if ($4 == 6)
-        error_message(2);
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte($4 | 0x30);
-    }
-  | MNEMO_SLL indirect_IY ',' REGISTER {
-      if ($4 == 6)
-        error_message(2);
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte($4 | 0x30);
-    }
-  | MNEMO_SLL indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte(0x36);
-    }
-  | MNEMO_SLL indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte(0x36);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_SLL indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($5);
-      write_byte(0x30 | $2);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_SLL indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($5);
-      write_byte(0x30 | $2);
-    }
-  | MNEMO_SRA REGISTER {
-      write_byte(0xcb);
-      write_byte(0x28 | $2);
-    }
-  | MNEMO_SRA REGISTER_IND_HL {
-      write_byte(0xcb);
-      write_byte(0x2e);
-    }
-  | MNEMO_SRA indirect_IX ',' REGISTER {
-      if ($4 == 6)
-        error_message(2);
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte($4 | 0x28);
-    }
-  | MNEMO_SRA indirect_IY ',' REGISTER {
-      if ($4 == 6)
-        error_message(2);
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte($4 | 0x28);
-    }
-  | MNEMO_SRA indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte(0x2e);
-    }
-  | MNEMO_SRA indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte(0x2e);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_SRA indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($5);
-      write_byte(0x28 | $2);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_SRA indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($5);
-      write_byte(0x28 | $2);
-    }
-  | MNEMO_SRL REGISTER {
-      write_byte(0xcb);
-      write_byte(0x38 | $2);
-    }
-  | MNEMO_SRL REGISTER_IND_HL {
-      write_byte(0xcb);
-      write_byte(0x3e);
-    }
-  | MNEMO_SRL indirect_IX ',' REGISTER {
-      if ($4 == 6)
-        error_message(2);
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte($4 | 0x38);
-    }
-  | MNEMO_SRL indirect_IY ',' REGISTER {
-      if ($4 == 6)
-        error_message(2);
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte($4 | 0x38);
-    }
-  | MNEMO_SRL indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte(0x3e);
-    }
-  | MNEMO_SRL indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($2);
-      write_byte(0x3e);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_SRL indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($5);
-      write_byte(0x38 | $2);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_SRL indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($5);
-      write_byte(0x38|$2);
-    }
-  | MNEMO_RLD {
-      write_byte(0xed);
-      write_byte(0x6f);
-    }
-  | MNEMO_RRD {
-      write_byte(0xed);
-      write_byte(0x67);
-    }
+mnemo_rotate: MNEMO_RLCA
+	{
+		write_byte(0x07);
+	}
+	| MNEMO_RLA
+	{
+		write_byte(0x17);
+	}
+	| MNEMO_RRCA
+	{
+		write_byte(0x0f);
+	}
+	| MNEMO_RRA
+	{
+		write_byte(0x1f);
+	}
+	| MNEMO_RLC REGISTER
+	{
+		write_byte(0xcb);
+		write_byte($2);
+	}
+	| MNEMO_RLC REGISTER_IND_HL
+	{
+		write_byte(0xcb);
+		write_byte(0x06);
+	}
+	| MNEMO_RLC indirect_IX ',' REGISTER
+	{
+		if ($4 == 6)
+			error_message(2);
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte($4);
+	}
+	| MNEMO_RLC indirect_IY ',' REGISTER
+	{
+		if ($4 == 6)
+			error_message(2);
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte($4);
+	}
+	| MNEMO_RLC indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte(0x06);
+	}
+	| MNEMO_RLC indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte(0x06);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_RLC indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($5);
+		write_byte($2);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_RLC indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($5);
+		write_byte($2);
+	}
+	| MNEMO_RL REGISTER
+	{
+		write_byte(0xcb);
+		write_byte(0x10 | $2);
+	}
+	| MNEMO_RL REGISTER_IND_HL
+	{
+		write_byte(0xcb);
+		write_byte(0x16);
+	}
+	| MNEMO_RL indirect_IX ',' REGISTER
+	{
+		if ($4 == 6)
+			error_message(2);
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte($4 | 0x10);
+	}
+	| MNEMO_RL indirect_IY ',' REGISTER
+	{
+		if ($4 == 6)
+			error_message(2);
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte($4 | 0x10);
+	}
+	| MNEMO_RL indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte(0x16);
+	}
+	| MNEMO_RL indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte(0x16);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_RL indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($5);
+		write_byte(0x10 | $2);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_RL indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($5);
+		write_byte(0x10 | $2);
+	}
+	| MNEMO_RRC REGISTER
+	{
+		write_byte(0xcb);
+		write_byte(0x08 | $2);
+	}
+	| MNEMO_RRC REGISTER_IND_HL
+	{
+		write_byte(0xcb);
+		write_byte(0x0e);
+	}
+	| MNEMO_RRC indirect_IX ',' REGISTER
+	{
+		if ($4 == 6)
+			error_message(2);
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte($4 | 0x08);
+	}
+	| MNEMO_RRC indirect_IY ',' REGISTER
+	{
+		if ($4 == 6)
+			error_message(2);
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte($4 | 0x08);
+	}
+	| MNEMO_RRC indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte(0x0e);
+	}
+	| MNEMO_RRC indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte(0x0e);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_RRC indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($5);
+		write_byte(0x08 | $2);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_RRC indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($5);
+		write_byte(0x08 | $2);
+	}
+	| MNEMO_RR REGISTER
+	{
+		write_byte(0xcb);
+		write_byte(0x18 | $2);
+	}
+	| MNEMO_RR REGISTER_IND_HL
+	{
+		write_byte(0xcb);
+		write_byte(0x1e);
+	}
+	| MNEMO_RR indirect_IX ',' REGISTER
+	{
+		if ($4 == 6)
+			error_message(2);
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte($4 | 0x18);
+	}
+	| MNEMO_RR indirect_IY ',' REGISTER
+	{
+		if ($4 == 6)
+			error_message(2);
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte($4 | 0x18);
+	}
+	| MNEMO_RR indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte(0x1e);
+	}
+	| MNEMO_RR indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte(0x1e);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_RR indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($5);
+		write_byte(0x18 | $2);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_RR indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($5);
+		write_byte(0x18 | $2);
+	}
+	| MNEMO_SLA REGISTER
+	{
+		write_byte(0xcb);
+		write_byte(0x20 | $2);
+	}
+	| MNEMO_SLA REGISTER_IND_HL
+	{
+		write_byte(0xcb);
+		write_byte(0x26);
+	}
+	| MNEMO_SLA indirect_IX ',' REGISTER
+	{
+		if ($4 == 6)
+			error_message(2);
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte($4 | 0x20);
+	}
+	| MNEMO_SLA indirect_IY ',' REGISTER
+	{
+		if ($4 == 6)
+			error_message(2);
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte($4 | 0x20);
+	}
+	| MNEMO_SLA indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte(0x26);
+	}
+	| MNEMO_SLA indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte(0x26);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_SLA indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($5);
+		write_byte(0x20 | $2);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_SLA indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($5);
+		write_byte(0x20 | $2);
+	}
+	| MNEMO_SLL REGISTER
+	{
+		write_byte(0xcb);
+		write_byte(0x30 | $2);
+	}
+	| MNEMO_SLL REGISTER_IND_HL
+	{
+		write_byte(0xcb);
+		write_byte(0x36);
+	}
+	| MNEMO_SLL indirect_IX ',' REGISTER
+	{
+		if ($4 == 6)
+			error_message(2);
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte($4 | 0x30);
+	}
+	| MNEMO_SLL indirect_IY ',' REGISTER
+	{
+		if ($4 == 6)
+			error_message(2);
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte($4 | 0x30);
+	}
+	| MNEMO_SLL indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte(0x36);
+	}
+	| MNEMO_SLL indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte(0x36);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_SLL indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($5);
+		write_byte(0x30 | $2);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_SLL indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($5);
+		write_byte(0x30 | $2);
+	}
+	| MNEMO_SRA REGISTER
+	{
+		write_byte(0xcb);
+		write_byte(0x28 | $2);
+	}
+	| MNEMO_SRA REGISTER_IND_HL
+	{
+		write_byte(0xcb);
+		write_byte(0x2e);
+	}
+	| MNEMO_SRA indirect_IX ',' REGISTER
+	{
+		if ($4 == 6)
+			error_message(2);
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte($4 | 0x28);
+	}
+	| MNEMO_SRA indirect_IY ',' REGISTER
+	{
+		if ($4 == 6)
+			error_message(2);
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte($4 | 0x28);
+	}
+	| MNEMO_SRA indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte(0x2e);
+	}
+	| MNEMO_SRA indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte(0x2e);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_SRA indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($5);
+		write_byte(0x28 | $2);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_SRA indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($5);
+		write_byte(0x28 | $2);
+	}
+	| MNEMO_SRL REGISTER
+	{
+		write_byte(0xcb);
+		write_byte(0x38 | $2);
+	}
+	| MNEMO_SRL REGISTER_IND_HL
+	{
+		write_byte(0xcb);
+		write_byte(0x3e);
+	}
+	| MNEMO_SRL indirect_IX ',' REGISTER
+	{
+		if ($4 == 6)
+			error_message(2);
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte($4 | 0x38);
+	}
+	| MNEMO_SRL indirect_IY ',' REGISTER
+	{
+		if ($4 == 6)
+			error_message(2);
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte($4 | 0x38);
+	}
+	| MNEMO_SRL indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte(0x3e);
+	}
+	| MNEMO_SRL indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($2);
+		write_byte(0x3e);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_SRL indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($5);
+		write_byte(0x38 | $2);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_SRL indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($5);
+		write_byte(0x38|$2);
+	}
+	| MNEMO_RLD
+	{
+		write_byte(0xed);
+		write_byte(0x6f);
+	}
+	| MNEMO_RRD
+	{
+		write_byte(0xed);
+		write_byte(0x67);
+	}
 ;
 
-mnemo_bits: MNEMO_BIT value_3bits ',' REGISTER {
-      write_byte(0xcb);
-      write_byte(0x40 | ($2 << 3) | ($4));
+mnemo_bits: MNEMO_BIT value_3bits ',' REGISTER
+	{
+		write_byte(0xcb);
+		write_byte(0x40 | ($2 << 3) | ($4));
+	}
+	| MNEMO_BIT value_3bits ',' REGISTER_IND_HL
+	{
+		write_byte(0xcb);
+		write_byte(0x46 | ($2 << 3));
+	}
+	| MNEMO_BIT value_3bits ',' indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($4);
+		write_byte(0x46 | ($2 << 3));
+	}
+	| MNEMO_BIT value_3bits ',' indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($4);
+		write_byte(0x46 | ($2 << 3));
+	}
+	| MNEMO_SET value_3bits ',' REGISTER
+	{
+		write_byte(0xcb);
+		write_byte(0xc0 | ($2 << 3) | ($4));
+	}
+	| MNEMO_SET value_3bits ',' REGISTER_IND_HL
+	{
+		write_byte(0xcb);
+		write_byte(0xc6 | ($2 << 3));
     }
-  | MNEMO_BIT value_3bits ',' REGISTER_IND_HL {
-      write_byte(0xcb);
-      write_byte(0x46 | ($2 << 3));
-    }
-  | MNEMO_BIT value_3bits ',' indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($4);
-      write_byte(0x46 | ($2 << 3));
-    }
-  | MNEMO_BIT value_3bits ',' indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($4);
-      write_byte(0x46 | ($2 << 3));
-    }
-  | MNEMO_SET value_3bits ',' REGISTER {
-      write_byte(0xcb);
-      write_byte(0xc0 | ($2 << 3) | ($4));
-    }
-  | MNEMO_SET value_3bits ',' REGISTER_IND_HL {
-      write_byte(0xcb);
-      write_byte(0xc6 | ($2 << 3));
-    }
-  | MNEMO_SET value_3bits ',' indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($4);
-      write_byte(0xc6 | ($2 << 3));
-    }
-  | MNEMO_SET value_3bits ',' indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($4);
-      write_byte(0xc6 | ($2 << 3));
-    }
-  | MNEMO_SET value_3bits ',' indirect_IX ',' REGISTER {
-      if ($6 == 6)
-        error_message(2);
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($4);
-      write_byte(0xc0 | ($2 << 3) | $6);
-    }
-  | MNEMO_SET value_3bits ',' indirect_IY ',' REGISTER {
-      if ($6 == 6)
-        error_message(2);
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($4);
-      write_byte(0xc0 | ($2 << 3) | $6);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_SET value_3bits ',' indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($7);
-      write_byte(0xc0 | ($5 << 3) | $2);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_SET value_3bits ',' indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($7);
-      write_byte(0xc0 | ($5 << 3) | $2);
-    }
-  | MNEMO_RES value_3bits ',' REGISTER {
-      write_byte(0xcb);
-      write_byte(0x80 | ($2 << 3) | ($4));
-    }
-  | MNEMO_RES value_3bits ',' REGISTER_IND_HL {
-      write_byte(0xcb);
-      write_byte(0x86 | ($2 << 3));
-    }
-  | MNEMO_RES value_3bits ',' indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($4);
-      write_byte(0x86 | ($2 << 3));
-    }
-  | MNEMO_RES value_3bits ',' indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($4);
-      write_byte(0x86 | ($2 << 3));
-    }
-  | MNEMO_RES value_3bits ',' indirect_IX ',' REGISTER {
-      if ($6 == 6)
-        error_message(2);
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($4);
-      write_byte(0x80 | ($2 << 3) | $6);
-    }
-  | MNEMO_RES value_3bits ',' indirect_IY ',' REGISTER {
-      if ($6 == 6)
-        error_message(2);
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($4);
-      write_byte(0x80 | ($2 << 3) | $6);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_RES value_3bits ',' indirect_IX {
-      write_byte(0xdd);
-      write_byte(0xcb);
-      write_byte($7);
-      write_byte(0x80 | ($5 << 3) | $2);
-    }
-  | MNEMO_LD REGISTER ',' MNEMO_RES value_3bits ',' indirect_IY {
-      write_byte(0xfd);
-      write_byte(0xcb);
-      write_byte($7);
-      write_byte(0x80 | ($5 << 3) | $2);
-    }
+	| MNEMO_SET value_3bits ',' indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($4);
+		write_byte(0xc6 | ($2 << 3));
+	}
+	| MNEMO_SET value_3bits ',' indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($4);
+		write_byte(0xc6 | ($2 << 3));
+	}
+	| MNEMO_SET value_3bits ',' indirect_IX ',' REGISTER
+	{
+		if ($6 == 6)
+			error_message(2);
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($4);
+		write_byte(0xc0 | ($2 << 3) | $6);
+	}
+	| MNEMO_SET value_3bits ',' indirect_IY ',' REGISTER
+	{
+		if ($6 == 6)
+			error_message(2);
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($4);
+		write_byte(0xc0 | ($2 << 3) | $6);
+		}
+	| MNEMO_LD REGISTER ',' MNEMO_SET value_3bits ',' indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($7);
+		write_byte(0xc0 | ($5 << 3) | $2);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_SET value_3bits ',' indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($7);
+		write_byte(0xc0 | ($5 << 3) | $2);
+	}
+	| MNEMO_RES value_3bits ',' REGISTER
+	{
+		write_byte(0xcb);
+		write_byte(0x80 | ($2 << 3) | ($4));
+	}
+	| MNEMO_RES value_3bits ',' REGISTER_IND_HL
+	{
+		write_byte(0xcb);
+		write_byte(0x86 | ($2 << 3));
+	}
+	| MNEMO_RES value_3bits ',' indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($4);
+		write_byte(0x86 | ($2 << 3));
+	}
+	| MNEMO_RES value_3bits ',' indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($4);
+		write_byte(0x86 | ($2 << 3));
+	}
+	| MNEMO_RES value_3bits ',' indirect_IX ',' REGISTER
+	{
+		if ($6 == 6)
+			error_message(2);
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($4);
+		write_byte(0x80 | ($2 << 3) | $6);
+	}
+	| MNEMO_RES value_3bits ',' indirect_IY ',' REGISTER
+	{
+		if ($6 == 6)
+			error_message(2);
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($4);
+		write_byte(0x80 | ($2 << 3) | $6);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_RES value_3bits ',' indirect_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xcb);
+		write_byte($7);
+		write_byte(0x80 | ($5 << 3) | $2);
+	}
+	| MNEMO_LD REGISTER ',' MNEMO_RES value_3bits ',' indirect_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xcb);
+		write_byte($7);
+		write_byte(0x80 | ($5 << 3) | $2);
+	}
 ;
 
-mnemo_io: MNEMO_IN REGISTER ',' '[' value_8bits ']' {
-      if ($2 != 7)
-        error_message(4);
-      write_byte(0xdb);
-      write_byte($5);
-    }
-  | MNEMO_IN REGISTER ',' value_8bits {
-      if ($2 != 7)
-        error_message(4);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdb);
-      write_byte($4);
-    }
-  | MNEMO_IN REGISTER ',' '[' REGISTER ']' {
-      if ($5 != 1)
-        error_message(2);
-      write_byte(0xed);
-      write_byte(0x40 | ($2 << 3));
-    }
-  | MNEMO_IN '[' REGISTER ']'{
-      if ($3 != 1)
-        error_message(2);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xed);
-      write_byte(0x70);
-    }
-  | MNEMO_IN REGISTER_F ',' '[' REGISTER ']' {
-      if ($5 != 1)
-        error_message(2);
-      write_byte(0xed);
-      write_byte(0x70);
-    }
-  | MNEMO_INI {
-      write_byte(0xed);
-      write_byte(0xa2);
-    }
-  | MNEMO_INIR {
-      write_byte(0xed);
-      write_byte(0xb2);
-    }
-  | MNEMO_IND {
-      write_byte(0xed);
-      write_byte(0xaa);
-    }
-  | MNEMO_INDR {
-      write_byte(0xed);
-      write_byte(0xba);
-    }
-  | MNEMO_OUT '[' value_8bits ']' ',' REGISTER {
-      if ($6 != 7)
-        error_message(5);
-      write_byte(0xd3);
-      write_byte($3);
-    }
-  | MNEMO_OUT value_8bits ',' REGISTER {
-      if ($4 != 7)
-        error_message(5);
-      if (zilog)
-        warning_message(5);
-      write_byte(0xd3);
-      write_byte($2);
-    }
-  | MNEMO_OUT '[' REGISTER ']' ',' REGISTER {
-      if ($3 != 1)
-        error_message(2);
-      write_byte(0xed);
-      write_byte(0x41 | ($6 << 3));
-    }
-  | MNEMO_OUT '[' REGISTER ']' ',' value_8bits {
-      if ($3 != 1)
-        error_message(2);
-      if ($6 != 0)
-        error_message(6);
-      write_byte(0xed);
-      write_byte(0x71);
-    }
-  | MNEMO_OUTI {
-      write_byte(0xed);
-      write_byte(0xa3);
-    }
-  | MNEMO_OTIR {
-      write_byte(0xed);
-      write_byte(0xb3);
-    }
-  | MNEMO_OUTD {
-      write_byte(0xed);
-      write_byte(0xab);
-    }
-  | MNEMO_OTDR {
-      write_byte(0xed);
-      write_byte(0xbb);
-    }
-  | MNEMO_IN '[' value_8bits ']' {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdb);
-      write_byte($3);
-    }
-  | MNEMO_IN value_8bits {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xdb);
-      write_byte($2);
-    }
-  | MNEMO_OUT '[' value_8bits ']' {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xd3);
-      write_byte($3);
-    }
-  | MNEMO_OUT value_8bits {
-      if (zilog)
-        warning_message(5);
-      write_byte(0xd3);
-      write_byte($2);
-    }
+mnemo_io: MNEMO_IN REGISTER ',' '[' value_8bits ']'
+	{
+		if ($2 != 7)
+			error_message(4);
+		write_byte(0xdb);
+		write_byte($5);
+	}
+	| MNEMO_IN REGISTER ',' value_8bits
+	{
+		if ($2 != 7)
+			error_message(4);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdb);
+		write_byte($4);
+	}
+	| MNEMO_IN REGISTER ',' '[' REGISTER ']'
+	{
+		if ($5 != 1)
+			error_message(2);
+		write_byte(0xed);
+		write_byte(0x40 | ($2 << 3));
+	}
+	| MNEMO_IN '[' REGISTER ']'
+	{
+		if ($3 != 1)
+			error_message(2);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xed);
+		write_byte(0x70);
+	}
+	| MNEMO_IN REGISTER_F ',' '[' REGISTER ']'
+	{
+		if ($5 != 1)
+			error_message(2);
+		write_byte(0xed);
+		write_byte(0x70);
+	}
+	| MNEMO_INI
+	{
+		write_byte(0xed);
+		write_byte(0xa2);
+	}
+	| MNEMO_INIR
+	{
+		write_byte(0xed);
+		write_byte(0xb2);
+	}
+	| MNEMO_IND
+	{
+		write_byte(0xed);
+		write_byte(0xaa);
+	}
+	| MNEMO_INDR
+	{
+		write_byte(0xed);
+		write_byte(0xba);
+	}
+	| MNEMO_OUT '[' value_8bits ']' ',' REGISTER
+	{
+		if ($6 != 7)
+			error_message(5);
+		write_byte(0xd3);
+		write_byte($3);
+	}
+	| MNEMO_OUT value_8bits ',' REGISTER
+	{
+		if ($4 != 7)
+			error_message(5);
+		if (zilog)
+			warning_message(5);
+		write_byte(0xd3);
+		write_byte($2);
+	}
+	| MNEMO_OUT '[' REGISTER ']' ',' REGISTER
+	{
+		if ($3 != 1)
+			error_message(2);
+		write_byte(0xed);
+		write_byte(0x41 | ($6 << 3));
+	}
+	| MNEMO_OUT '[' REGISTER ']' ',' value_8bits
+	{
+		if ($3 != 1)
+			error_message(2);
+		if ($6 != 0)
+			error_message(6);
+		write_byte(0xed);
+		write_byte(0x71);
+	}
+	| MNEMO_OUTI
+	{
+		write_byte(0xed);
+		write_byte(0xa3);
+	}
+	| MNEMO_OTIR
+	{
+		write_byte(0xed);
+		write_byte(0xb3);
+	}
+	| MNEMO_OUTD
+	{
+		write_byte(0xed);
+		write_byte(0xab);
+	}
+	| MNEMO_OTDR
+	{
+		write_byte(0xed);
+		write_byte(0xbb);
+	}
+	| MNEMO_IN '[' value_8bits ']'
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdb);
+		write_byte($3);
+	}
+	| MNEMO_IN value_8bits
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xdb);
+		write_byte($2);
+	}
+	| MNEMO_OUT '[' value_8bits ']'
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xd3);
+		write_byte($3);
+	}
+	| MNEMO_OUT value_8bits
+	{
+		if (zilog)
+			warning_message(5);
+		write_byte(0xd3);
+		write_byte($2);
+	}
 ;
 
-mnemo_jump: MNEMO_JP value_16bits {
-      write_byte(0xc3);
-      write_word($2);
+mnemo_jump: MNEMO_JP value_16bits
+	{
+		write_byte(0xc3);
+		write_word($2);
+	}
+	| MNEMO_JP CONDITION ',' value_16bits
+	{
+		write_byte(0xc2 | ($2 << 3));
+		write_word($4);
+	}
+	| MNEMO_JP REGISTER ',' value_16bits
+	{
+		if ($2 != 1)
+			error_message(7);
+		write_byte(0xda);
+		write_word($4);
+	}
+	| MNEMO_JR value_16bits
+	{
+		write_byte(0x18);
+		relative_jump($2);
     }
-  | MNEMO_JP CONDITION ',' value_16bits {
-      write_byte(0xc2 | ($2 << 3));
-      write_word($4);
-    }
-  | MNEMO_JP REGISTER ',' value_16bits {
-      if ($2 != 1)
-        error_message(7);
-      write_byte(0xda);
-      write_word($4);
-    }
-  | MNEMO_JR value_16bits {
-      write_byte(0x18);
-      relative_jump($2);
-    }
-  | MNEMO_JR REGISTER ',' value_16bits {
-      if ($2 != 1)
-        error_message(7);
-      write_byte(0x38);
-      relative_jump($4);
-    }
-  | MNEMO_JR CONDITION ',' value_16bits {
-      if ($2 == 2)
-        write_byte(0x30);
-      else if ($2 == 1)
-        write_byte(0x28);
-      else if ($2 == 0)
-        write_byte(0x20);
-      else
-        error_message(9);
-      relative_jump($4);
-    }
-  | MNEMO_JP REGISTER_PAIR {
-      if ($2 != 2)
-        error_message(2);
-      write_byte(0xe9);
-    }
-  | MNEMO_JP REGISTER_IND_HL {
-      write_byte(0xe9);
-    }
-  | MNEMO_JP REGISTER_16_IX {
-      write_byte(0xdd);
-      write_byte(0xe9);
-    }
-  | MNEMO_JP REGISTER_16_IY {
-      write_byte(0xfd);
-      write_byte(0xe9);
-    }
-  | MNEMO_JP '[' REGISTER_16_IX ']' {
-      write_byte(0xdd);
-      write_byte(0xe9);
-    }
-  | MNEMO_JP '[' REGISTER_16_IY ']' {
-      write_byte(0xfd);
-      write_byte(0xe9);
-    }
-  | MNEMO_DJNZ value_16bits {
-      write_byte(0x10);
-      relative_jump($2);
-    }
+	| MNEMO_JR REGISTER ',' value_16bits
+	{
+		if ($2 != 1)
+			error_message(7);
+		write_byte(0x38);
+		relative_jump($4);
+	}
+	| MNEMO_JR CONDITION ',' value_16bits
+	{
+		if ($2 == 2)
+			write_byte(0x30);
+		else if ($2 == 1)
+			write_byte(0x28);
+		else if ($2 == 0)
+			write_byte(0x20);
+		else
+			error_message(9);
+		relative_jump($4);
+	}
+	| MNEMO_JP REGISTER_PAIR
+	{
+		if ($2 != 2)
+			error_message(2);
+		write_byte(0xe9);
+	}
+	| MNEMO_JP REGISTER_IND_HL
+	{
+		write_byte(0xe9);
+	}
+	| MNEMO_JP REGISTER_16_IX
+	{
+		write_byte(0xdd);
+		write_byte(0xe9);
+		}
+	| MNEMO_JP REGISTER_16_IY
+	{
+		write_byte(0xfd);
+		write_byte(0xe9);
+	}
+	| MNEMO_JP '[' REGISTER_16_IX ']'
+	{
+		write_byte(0xdd);
+		write_byte(0xe9);
+	}
+	| MNEMO_JP '[' REGISTER_16_IY ']'
+	{
+		write_byte(0xfd);
+		write_byte(0xe9);
+	}
+	| MNEMO_DJNZ value_16bits
+	{
+		write_byte(0x10);
+		relative_jump($2);
+	}
 ;
 
-mnemo_call: MNEMO_CALL value_16bits {
-      write_byte(0xcd);
-      write_word($2);
-    }
-  | MNEMO_CALL CONDITION ',' value_16bits {
-      write_byte(0xc4 | ($2 << 3));
-      write_word($4);
-    }
-  | MNEMO_CALL REGISTER ',' value_16bits {
-      if ($2 != 1)
-        error_message(7);
-      write_byte(0xdc);
-      write_word($4);
-    }
-  | MNEMO_RET {
-      write_byte(0xc9);
-    }
-  | MNEMO_RET CONDITION {
-      write_byte(0xc0 | ($2 << 3));
-    }
-  | MNEMO_RET REGISTER {
-      if ($2 != 1)
-        error_message(7);
-      write_byte(0xd8);
-    }
-  | MNEMO_RETI {
-      write_byte(0xed);
-      write_byte(0x4d);
-    }
-  | MNEMO_RETN {
-      write_byte(0xed);
-      write_byte(0x45);
-    }
-  | MNEMO_RST value_8bits {
-      if (($2 % 8 != 0) || ($2 / 8 > 7) || ($2 / 8 < 0))
-        error_message(10);
-      write_byte(0xc7 | (($2 / 8) << 3));
-    }
+mnemo_call: MNEMO_CALL value_16bits
+	{
+		write_byte(0xcd);
+		write_word($2);
+	}
+	| MNEMO_CALL CONDITION ',' value_16bits
+	{
+		write_byte(0xc4 | ($2 << 3));
+		write_word($4);
+	}
+	| MNEMO_CALL REGISTER ',' value_16bits
+	{
+		if ($2 != 1)
+			error_message(7);
+		write_byte(0xdc);
+		write_word($4);
+	}
+	| MNEMO_RET
+	{
+		write_byte(0xc9);
+	}
+	| MNEMO_RET CONDITION
+	{
+		write_byte(0xc0 | ($2 << 3));
+	}
+	| MNEMO_RET REGISTER
+	{
+		if ($2 != 1)
+			error_message(7);
+		write_byte(0xd8);
+	}
+	| MNEMO_RETI
+	{
+		write_byte(0xed);
+		write_byte(0x4d);
+	}
+	| MNEMO_RETN
+	{
+		write_byte(0xed);
+		write_byte(0x45);
+	}
+	| MNEMO_RST value_8bits
+	{
+		if (($2 % 8 != 0) || ($2 / 8 > 7) || ($2 / 8 < 0))
+			error_message(10);
+		write_byte(0xc7 | (($2 / 8) << 3));
+	}
 
-value: NUMBER {
-      $$ = $1;
+value: NUMBER
+	{
+		$$ = $1;
+	}
+	| IDENTIFICATOR
+	{
+		$$ = read_label($1);
+	}
+	| LOCAL_IDENTIFICATOR
+	{
+		$$ = read_local($1);
+	}
+	| '-' value %prec NEGATIVE
+	{
+		$$ = -$2;
+	}
+	| value OP_EQUAL value
+	{
+		$$ = ($1 == $3);
+	}
+	| value OP_LESS_OR_EQUAL value
+	{
+		$$ = ($1 <= $3);
+	}
+	| value OP_LESS value
+	{
+		$$ = ($1 < $3);
+	}
+	| value OP_MORE_OR_EQUAL value
+	{
+		$$ = ($1 >= $3);
+	}
+	| value OP_MORE value
+	{
+		$$ = ($1 > $3);
+	}
+	| value OP_NOT_EQUAL value
+	{
+		$$ = ($1 != $3);
+	}
+	| value OP_OR_LOG value
+	{
+		$$ = ($1 || $3);
+	}
+	| value OP_AND_LOG value {$$ = ($1 && $3);
     }
-  | IDENTIFICATOR {
-      $$ = read_label($1);
-    }
-  | LOCAL_IDENTIFICATOR {
-      $$ = read_local($1);
-    }
-  | '-' value %prec NEGATIVE {
-      $$ = -$2;
-    }
-  | value OP_EQUAL value {
-      $$ = ($1 == $3);
-    }
-  | value OP_LESS_OR_EQUAL value {
-      $$ = ($1 <= $3);
-    }
-  | value OP_LESS value {
-      $$ = ($1 < $3);
-    }
-  | value OP_MORE_OR_EQUAL value {
-      $$ = ($1 >= $3);
-    }
-  | value OP_MORE value {
-      $$ = ($1 > $3);
-    }
-  | value OP_NOT_EQUAL value {
-      $$ = ($1 != $3);
-    }
-  | value OP_OR_LOG value {
-      $$ = ($1 || $3);
-    }
-  | value OP_AND_LOG value {$$ = ($1 && $3);
-    }
-  | value '+' value {
-      $$ = $1 + $3;
-    }
-  | value '-' value {
-      $$ = $1 - $3;
-    }
-  | value '*' value {
-      $$ = $1 * $3;
-    }
-  | value '/' value {
-      if (!$3)
-        error_message(1);
-      else
-        $$ = $1 / $3;
-    }
-  | value '%' value {
-      if (!$3)
-        error_message(1);
-      else
-        $$ = $1 % $3;
-    }
-  | '(' value ')' {
-      $$ = $2;
-    }
-  | '~' value %prec NEGATION {
-      $$ =~ $2;
-    }
-  | '!' value %prec OP_NEG_LOG {
-      $$ =! $2;
-    }
-  | value '&' value {
-      $$ = $1 & $3;
-    }
-  | value OP_OR value {
-      $$ = $1 | $3;
-    }
-  | value OP_XOR value {
-      $$ = $1 ^ $3;
-    }
-  | value SHIFT_L value {
-      $$ = $1 << $3;
-    }
-  | value SHIFT_R value {
-      $$ = $1 >> $3;
-    }
-  | PSEUDO_RANDOM '(' value ')' {
-    for (; ($$ = d_rand() & 0xff) >= $3;)
-      ;
-    }
-  | PSEUDO_INT '(' value_real ')' {
-      $$ = (int)$3;
-    }
-  | PSEUDO_FIX '(' value_real ')' {
-      $$ = (int)($3 * 256);
-    }
-  | PSEUDO_FIXMUL '(' value ',' value ')' {
-      $$ = (int)((((float)$3 / 256) * ((float) $5 / 256)) * 256);
-    }
-  | PSEUDO_FIXDIV '(' value ',' value ')' {
-      $$ = (int)((((float)$3 / 256) / ((float)$5 / 256)) * 256);
-    }
+	| value '+' value
+	{
+		$$ = $1 + $3;
+	}
+	| value '-' value
+	{
+		$$ = $1 - $3;
+	}
+	| value '*' value
+	{
+		$$ = $1 * $3;
+	}
+	| value '/' value
+	{
+		if (!$3)
+			error_message(1);
+		else
+			$$ = $1 / $3;
+	}
+	| value '%' value
+	{
+		if (!$3)
+			error_message(1);
+		else
+			$$ = $1 % $3;
+	}
+	| '(' value ')'
+	{
+		$$ = $2;
+	}
+	| '~' value %prec NEGATION
+	{
+		$$ =~ $2;
+	}
+	| '!' value %prec OP_NEG_LOG
+	{
+		$$ =! $2;
+	}
+	| value '&' value
+	{
+		$$ = $1 & $3;
+	}
+	| value OP_OR value
+	{
+		$$ = $1 | $3;
+	}
+	| value OP_XOR value
+	{
+		$$ = $1 ^ $3;
+	}
+	| value SHIFT_L value
+	{
+		$$ = $1 << $3;
+	}
+	| value SHIFT_R value
+	{
+		$$ = $1 >> $3;
+	}
+	| PSEUDO_RANDOM '(' value ')'
+	{
+		for (; ($$ = d_rand() & 0xff) >= $3;)
+			;
+	}
+	| PSEUDO_INT '(' value_real ')'
+	{
+		$$ = (int)$3;
+	}
+	| PSEUDO_FIX '(' value_real ')'
+	{
+		$$ = (int)($3 * 256);
+	}
+	| PSEUDO_FIXMUL '(' value ',' value ')'
+	{
+		$$ = (int)((((float)$3 / 256) * ((float) $5 / 256)) * 256);
+	}
+	| PSEUDO_FIXDIV '(' value ',' value ')'
+	{
+		$$ = (int)((((float)$3 / 256) / ((float)$5 / 256)) * 256);
+	}
 ;
 
-value_real: REAL {
-      $$ = $1;
-    }
-  | '-' value_real {
-      $$ = -$2;
-    }
-  | value_real '+' value_real {
-      $$ = $1 + $3;
-    }
-  | value_real '-' value_real {
-      $$ = $1 - $3;
-    }
-  | value_real '*' value_real {
-      $$ = $1 * $3;
-    }
-  | value_real '/' value_real {
-      if (!$3)
-        error_message(1);
-      else
-        $$ = $1 / $3;
-    }
-  | value '+' value_real {
-      $$ = (double)$1 + $3;
-    }
-  | value '-' value_real {
-      $$ = (double)$1 - $3;
-    }
-  | value '*' value_real {
-      $$ = (double)$1 * $3;
-    }
-  | value '/' value_real {
-      if ($3 < 1e-6)
-        error_message(1);
-      else
-        $$ = (double)$1 / $3;
-    }
-  | value_real '+' value {
-      $$ = $1 + (double)$3;
-    }
-  | value_real '-' value {
-      $$ = $1 - (double)$3;
-    }
-  | value_real '*' value {
-      $$ = $1 * (double)$3;
-    }
-  | value_real '/' value {
-      if (!$3)
-        error_message(1);
-      else
-        $$ = $1 / (double)$3;
-    }
-  | PSEUDO_SIN '(' value_real ')' {
-      $$ = sin($3);
-    }
-  | PSEUDO_COS '(' value_real ')' {
-      $$ = cos($3);
-    }
-  | PSEUDO_TAN '(' value_real ')' {
-      $$ = tan($3);
-    }
-  | PSEUDO_SQR '(' value_real ')' {
-      $$ = $3 * $3;
-    }
-  | PSEUDO_SQRT '(' value_real ')' {
-      $$ = sqrt($3);
-    }
-  | PSEUDO_PI {
-      $$ = 3.14159265358979323846;	/* use this instead of M_PI to avoid slightly different ROMs depending on compiler */
-    }
-  | PSEUDO_ABS '(' value_real ')' {
-      $$ = abs((int)$3);
-    }
-  | PSEUDO_ACOS '(' value_real ')' {
-      $$ = acos($3);
-    }
-  | PSEUDO_ASIN '(' value_real ')' {
-      $$ = asin($3);
-    }
-  | PSEUDO_ATAN '(' value_real ')' {
-      $$ = atan($3);
-    }
-  | PSEUDO_EXP '(' value_real ')' {
-      $$ = exp($3);
-    }
-  | PSEUDO_LOG '(' value_real ')' {
-      $$ = log10($3);
-    }
-  | PSEUDO_LN '(' value_real ')' {
-      $$ = log($3);
-    }
-  | PSEUDO_POW '(' value_real ',' value_real ')' {
-      $$ = pow($3, $5);
-    }
-  | '(' value_real ')' {
-      $$ = $2;
-    }
+value_real: REAL
+	{
+		$$ = $1;
+	}
+	| '-' value_real
+	{
+		$$ = -$2;
+	}
+	| value_real '+' value_real
+	{
+		$$ = $1 + $3;
+	}
+	| value_real '-' value_real
+	{
+		$$ = $1 - $3;
+	}
+	| value_real '*' value_real
+	{
+		$$ = $1 * $3;
+	}
+	| value_real '/' value_real
+	{
+		if (!$3)
+			error_message(1);
+		else
+			$$ = $1 / $3;
+	}
+	| value '+' value_real
+	{
+		$$ = (double)$1 + $3;
+	}
+	| value '-' value_real
+	{
+		$$ = (double)$1 - $3;
+	}
+	| value '*' value_real
+	{
+		$$ = (double)$1 * $3;
+	}
+	| value '/' value_real
+	{
+		if ($3 < 1e-6)
+			error_message(1);
+		else
+			$$ = (double)$1 / $3;
+	}
+	| value_real '+' value
+	{
+		$$ = $1 + (double)$3;
+	}
+	| value_real '-' value
+	{
+		$$ = $1 - (double)$3;
+	}
+	| value_real '*' value
+	{
+		$$ = $1 * (double)$3;
+	}
+	| value_real '/' value
+	{
+		if (!$3)
+			error_message(1);
+		else
+			$$ = $1 / (double)$3;
+	}
+	| PSEUDO_SIN '(' value_real ')'
+	{
+		$$ = sin($3);
+	}
+	| PSEUDO_COS '(' value_real ')'
+	{
+		$$ = cos($3);
+	}
+	| PSEUDO_TAN '(' value_real ')'
+	{
+		$$ = tan($3);
+	}
+	| PSEUDO_SQR '(' value_real ')'
+	{
+		$$ = $3 * $3;
+	}
+	| PSEUDO_SQRT '(' value_real ')'
+	{
+		$$ = sqrt($3);
+	}
+	| PSEUDO_PI
+	{
+		$$ = 3.14159265358979323846;	/* use this instead of M_PI to avoid slightly different ROMs depending on compiler */
+	}
+	| PSEUDO_ABS '(' value_real ')'
+	{
+		$$ = abs((int)$3);
+	}
+	| PSEUDO_ACOS '(' value_real ')'
+	{
+		$$ = acos($3);
+	}
+	| PSEUDO_ASIN '(' value_real ')'
+	{
+		$$ = asin($3);
+	}
+	| PSEUDO_ATAN '(' value_real ')'
+	{
+		$$ = atan($3);
+	}
+	| PSEUDO_EXP '(' value_real ')'
+	{
+		$$ = exp($3);
+	}
+	| PSEUDO_LOG '(' value_real ')'
+	{
+		$$ = log10($3);
+	}
+	| PSEUDO_LN '(' value_real ')'
+	{
+		$$ = log($3);
+	}
+	| PSEUDO_POW '(' value_real ',' value_real ')'
+	{
+		$$ = pow($3, $5);
+	}
+	| '(' value_real ')'
+	{
+		$$ = $2;
+	}
 ;
 
-value_3bits: value {
-      if (($1 < 0) || ($1 > 7))
-        warning_message(3);
-      $$ = $1 & 0x07;
-    }
+value_3bits: value
+	{
+		if (($1 < 0) || ($1 > 7))
+			warning_message(3);
+		$$ = $1 & 0x07;
+	}
 ;
 
-value_8bits: value {
-      if (($1 > 255) || ($1 < -128))
-        warning_message(2);
-      $$ = $1 & 0xff;
-    }
+value_8bits: value
+	{
+		if (($1 > 255) || ($1 < -128))
+			warning_message(2);
+		$$ = $1 & 0xff;
+	}
 ;
 
-value_16bits: value {
-      if (($1 > 65535) || ($1 < -32768))
-        warning_message(1);
-      $$ = $1 & 0xffff;
-    }
+value_16bits: value
+	{
+		if (($1 > 65535) || ($1 < -32768))
+			warning_message(1);
+		$$ = $1 & 0xffff;
+	}
 ;
 
-list_8bits: value_8bits {
-      write_byte($1);
-    }
-  | TEXT {
-      write_string($1);
-    }
-  | list_8bits ',' value_8bits {
-      write_byte($3);
-    }
-  | list_8bits ',' TEXT {
-      write_string($3);
-    }
+list_8bits: value_8bits
+	{
+		write_byte($1);
+	}
+	| TEXT
+	{
+		write_string($1);
+	}
+	| list_8bits ',' value_8bits
+	{
+		write_byte($3);
+	}
+	| list_8bits ',' TEXT
+	{
+		write_string($3);
+	}
 ;
 
-list_16bits: value_16bits {
-      write_word($1);
-    }
-  | TEXT {
-      write_string($1);
-    }
-  | list_16bits ',' value_16bits {
-      write_word($3);
-    }
-  | list_16bits ',' TEXT {
-      write_string($3);
-    }
+list_16bits: value_16bits
+	{
+		write_word($1);
+	}
+	| TEXT
+	{
+		write_string($1);
+	}
+	| list_16bits ',' value_16bits
+	{
+		write_word($3);
+	}
+	| list_16bits ',' TEXT
+	{
+		write_string($3);
+	}
 ;
 
 %%

--- a/src/dura.y
+++ b/src/dura.y
@@ -1,7 +1,9 @@
 /* asMSX - an MSX / Z80 assembler
-	(c) 2013-2019 asMSX team
-	(c) 2000-2010 Eduardo A. Robsy Petrus
+
+	(c) 2000-2010 Eduardo A. Robsy Petrus, (c) 2013-2019 asMSX team
+
 	Bison grammar file
+
 	v.0.01a: [10/09/2000] First public version
 
 	v.0.01b: [03/05/2001] Bugfixes. Added PRINTFIX, FIXMUL, FIXDIV

--- a/src/dura.y
+++ b/src/dura.y
@@ -4343,7 +4343,6 @@ void type_megarom(int n)
 		run_address = ePC;
 }
 
-
 void type_basic()
 {
 	if ((pass == 1) && (!start_address))
@@ -4469,7 +4468,6 @@ void select_page_register(int r, int address)
 		write_byte(0xf1);					/* POP AF */
 }
 
-
 int is_defined_symbol(char *name)
 {
 	int i;
@@ -4479,20 +4477,6 @@ int is_defined_symbol(char *name)
 			return 1;
 	return 0;
 }
-
-
-/*
- Deterministic version of rand() to keep generated binary files
- consistent across platforms and compilers. Code snippet is from
- http://stackoverflow.com/questions/4768180/rand-implementation
-*/
-static unsigned long int rand_seed = 1;
-int d_rand()
-{
-	rand_seed = (rand_seed * 1103515245 + 12345);
-	return (unsigned int)(rand_seed / 65536) % (32767 + 1);
-}
-
 
 int main(int argc, char *argv[])
 {

--- a/src/dura.y
+++ b/src/dura.y
@@ -4046,67 +4046,73 @@ int d_rand()
 
 int main(int argc, char *argv[])
 {
-  FILE *f;
-  size_t t;
-  int fileArg = 1;
-  printf("-------------------------------------------------------------------------------\n");
-  printf(" asMSX v.%s. MSX cross-assembler. Eduardo A. Robsy Petrus [%s]\n", VERSION, DATE);
-  printf("-------------------------------------------------------------------------------\n");  
-  if (argc > 3 || argc < 2)
-  {
-    printf("Syntax: asMSX [-z] [file.asm]\n");
-    exit(0);
-  } else if (argc == 3) {
-    if (strcmp(argv[1], "-z") == 0) {
-	  zilog = 1;
-	  fileArg = 2;
-    } else {
-	  printf("Syntax: asMSX [-z] [file.asm]\n");
-	  exit(0);
-    }
-  }   
+	FILE *f;
+	size_t t;
+	int fileArg = 1;
+
+	printf("-------------------------------------------------------------------------------\n");
+	printf(" asMSX v.%s. MSX cross-assembler. Eduardo A. Robsy Petrus [%s]\n", VERSION, DATE);
+	printf("-------------------------------------------------------------------------------\n");
+
+	if (argc > 3 || argc < 2)
+	{
+		printf("Syntax: asMSX [-z] [file.asm]\n");
+		exit(0);
+	}
+	else if (argc == 3)
+	{
+		if (strcmp(argv[1], "-z") == 0)
+		{
+			zilog = 1;
+			fileArg = 2;
+		}
+		else
+		{
+			printf("Syntax: asMSX [-z] [file.asm]\n");
+			exit(0);
+		}
+	}   
   
-  clock();
-  initialize_system();
-  fname_asm = malloc(PATH_MAX + 1);
-  fname_src = malloc(PATH_MAX + 1);
-  fname_p2 = malloc(PATH_MAX + 1);
-  fname_bin = malloc(PATH_MAX + 1);
-  fname_sym = malloc(PATH_MAX + 1);
-  fname_txt = malloc(PATH_MAX + 1);
-  fname_no_ext = malloc(PATH_MAX + 1);
-  if (!fname_no_ext)
-  {
-    fprintf(stderr, "Error: can't allocate memory for fname_no_ext\n");
-    exit(1);
-  }
+	clock();
+	initialize_system();
+	fname_asm = malloc(PATH_MAX + 1);
+	fname_src = malloc(PATH_MAX + 1);
+	fname_p2 = malloc(PATH_MAX + 1);
+	fname_bin = malloc(PATH_MAX + 1);
+	fname_sym = malloc(PATH_MAX + 1);
+	fname_txt = malloc(PATH_MAX + 1);
+	fname_no_ext = malloc(PATH_MAX + 1);
+	if (!fname_no_ext)
+	{
+		fprintf(stderr, "Error: can't allocate memory for fname_no_ext\n");
+		exit(1);
+	}
 
-  strcpy(fname_no_ext, argv[fileArg]);
-  strcpy(fname_asm, fname_no_ext);
+	strcpy(fname_no_ext, argv[fileArg]);
+	strcpy(fname_asm, fname_no_ext);
 
-  for (t = strlen(fname_no_ext) - 1; (fname_no_ext[t] != '.') && t; t--);
+	for (t = strlen(fname_no_ext) - 1; (fname_no_ext[t] != '.') && t; t--);
 
-  if (t)
-    fname_no_ext[t] = 0;
-  else
-    strcat(fname_asm, ".asm");
+	if (t)
+		fname_no_ext[t] = 0;
+	else
+		strcat(fname_asm, ".asm");
 
-  /* Generate the name of binary file */
-  strcpy(fname_bin, fname_no_ext);
+	/* Generate the name of binary file */
+	strcpy(fname_bin, fname_no_ext);
 
-  preprocessor1(fname_asm);
-  preprocessor3(zilog);
-  snprintf(fname_p2, PATH_MAX, "~tmppre.%i", preprocessor2());
-  printf("Assembling source file %s\n", fname_asm);
+	preprocessor1(fname_asm);
+	preprocessor3(zilog);
+	snprintf(fname_p2, PATH_MAX, "~tmppre.%i", preprocessor2());
+	printf("Assembling source file %s\n", fname_asm);
 
-  conditional[0] = 1;
+	conditional[0] = 1;
 
-  f = fopen(fname_p2, "r");
+	f = fopen(fname_p2, "r");
+	yyin = f;
 
-  yyin = f;
+	yyparse();
 
-  yyparse();
-
-  remove("~tmppre.?");
-  return 0;
+	remove("~tmppre.?");
+	return 0;
 }

--- a/src/dura.y
+++ b/src/dura.y
@@ -1,58 +1,58 @@
 /* asMSX - an MSX / Z80 assembler
-   (C) Eduardo A. Robsy Petrus, 2000-2010
-   Bison grammar file
-         v.0.01a: [10/09/2000] First public version
+	(C) Eduardo A. Robsy Petrus, 2000-2010
+	Bison grammar file
+	v.0.01a: [10/09/2000] First public version
 
-         v.0.01b: [03/05/2001] Bugfixes. Added PRINTFIX, FIXMUL, FIXDIV
+	v.0.01b: [03/05/2001] Bugfixes. Added PRINTFIX, FIXMUL, FIXDIV
 
-         v.0.10 : [19/08/2004] Overall enhance. Opcodes 100% checked
+	v.0.10 : [19/08/2004] Overall enhance. Opcodes 100% checked
 
-         v.0.11 : [31/12/2004] IX, IY do accept negative or null offsets
+	v.0.11 : [31/12/2004] IX, IY do accept negative or null offsets
 
-         v.0.12 : [11/09/2005] Recovery version
-         Added REPT/ENDR, variables/constants, RANDOM, DEBUG blueMSX,
-                     BREAKPOINT blueMSX, PHASE/DEPHASE, $ symbol
+	v.0.12 : [11/09/2005] Recovery version
+		Added REPT/ENDR, variables/constants, RANDOM, DEBUG blueMSX,
+		BREAKPOINT blueMSX, PHASE/DEPHASE, $ symbol
 
-         v.0.12e: [07/10/2006]
-                     Additional parameters for INCBIN "file" [SKIP num] [SIZE num]
-                     Second page locating macro (32KB ROMs / megaROMs)
-                     Added experimental support for MegaROMs:
-                        * MEGAROM [mapper] - define mapper type
-                        * SUBPAGE [n] AT [address] - define page
-                        * SELECT [n] AT [address] - set page
+	v.0.12e: [07/10/2006]
+		Additional parameters for INCBIN "file" [SKIP num] [SIZE num]
+		Second page locating macro (32KB ROMs / megaROMs)
+		Added experimental support for MegaROMs:
+			* MEGAROM [mapper] - define mapper type
+			* SUBPAGE [n] AT [address] - define page
+			* SELECT [n] AT [address] - set page
 
-         v.0.12f: [16/11/2006]
-                     Several binary operators fixed
-                     Conditional assembly
+	v.0.12f: [16/11/2006]
+		Several binary operators fixed
+		Conditional assembly
 
-         v.0.12f1:[17/11/2006]
-                     Nested conditional assembly and other conditions
+	v.0.12f1:[17/11/2006]
+		Nested conditional assembly and other conditions
 
-         v.0.12g:[18/03/2007]
-                     PHASE/DEPHASE bug fixed
-                     Initial CAS format support
-                     WAV output added
-                     Enhanced conditional assembly: IFDEF
+	v.0.12g:[18/03/2007]
+		PHASE/DEPHASE bug fixed
+		Initial CAS format support
+		WAV output added
+		Enhanced conditional assembly: IFDEF
 
-         v.0.14: [UNRELEASED]
-		     First working Linux version
-		     Somewhat improved stability
+	v.0.14: [UNRELEASED]
+		First working Linux version
+		Somewhat improved stability
 
-         v.0.15: [UNRELEASED]
-                     ADD IX,HL and ADD IY,HL operations removed
-                     Label vs Macro collisions solved
-                     Overall improvement in pointer stability
-		     INCBIN now can SKIP and SIZE upto 32-bit 
+	v.0.15: [UNRELEASED]
+		ADD IX,HL and ADD IY,HL operations removed
+		Label vs Macro collisions solved
+		Overall improvement in pointer stability
+		INCBIN now can SKIP and SIZE upto 32-bit 
 
-         v.0.16: [CANDIDATE]
-		     First version fully developed in Linux
-		     Fixed bug affecting filename extensions
-		     Removed the weird IM 0/1 - apparently it is just a plain undocumented IM 0 opcode
-		     FILENAME directive to set assembler output filenames
-		     ZILOG directive for using Zilog style indirections and official syntax
-		     ROM/MEGAROM now have a standard 16 byte header
-		     Fixed a really annoying bug regarding $DB data read as pseudo DB
-		     SINCLAIR directive included to support TAP file generation (ouch!) --> STILL TO BE TESTED 
+	v.0.16: [CANDIDATE]
+		First version fully developed in Linux
+		Fixed bug affecting filename extensions
+		Removed the weird IM 0/1 - apparently it is just a plain undocumented IM 0 opcode
+		FILENAME directive to set assembler output filenames
+		ZILOG directive for using Zilog style indirections and official syntax
+		ROM/MEGAROM now have a standard 16 byte header
+		Fixed a really annoying bug regarding $DB data read as pseudo DB
+		SINCLAIR directive included to support TAP file generation (ouch!) --> STILL TO BE TESTED 
 
 		Pending:
 			- Adjust BIOS for SINCLAIR model?
@@ -60,28 +60,32 @@
 			- R800/Z80/8080/Gameboy support
 			- Sinclair ZX Spectrum TAP/TZX file format supported
 			
-	 [Post-Rosby versions]
-	 v.0.17: [19/12/2013]
+	[Post-Rosby versions]
+	v.0.17: [19/12/2013]
 		[FIX] Issue 1: Crash on Linux when including additional .asm files (by theNestruo)
 		[FIX] Issue 5: Non-zero exit code on errors (by theNestruo)
 
-	 v.0.18: [01/02/2017]
-	 	Fixed issue with .megaflashrom and the defines.
+	v.0.18: [01/02/2017]
+		Fixed issue with .megaflashrom and the defines.
 	 
-	 v.0.18.1: [11/02/2017]
-	 	Fixed multiple compilation warnings by specifying function parameters and return type explicitly
-                Fixed a problem with cassette file name generation due to uninitialized variable 'fname_bin'
-	 v.0.18.2: [25/05/2017]
-	 	Added -z flag. This flag allows using standard Zilog syntax without setting .ZILOG on the code.
-	 	Now local labels can be also set using .Local_Label along the previous @@Local_Label.
+	v.0.18.1: [11/02/2017]
+		Fixed multiple compilation warnings by specifying function parameters and return type explicitly
+		Fixed a problem with cassette file name generation due to uninitialized variable 'fname_bin'
+
+	v.0.18.2: [25/05/2017]
+		Added -z flag. This flag allows using standard Zilog syntax without setting .ZILOG on the code.
+		Now local labels can be also set using .Local_Label along the previous @@Local_Label.
 		Now .instruction are correctly parsed. For instance, before it was allowed to set "azilog", "bzilog"
-		instead of only allowing ".zilog" or "zilog". 
-	 v.0.18.3: [10/06/2017]
+		instead of only allowing ".zilog" or "zilog".
+
+	v.0.18.3: [10/06/2017]
 		Fixed induced bug of February 5th when using INCLUDE. Parser 1 p1_tmpstr wasn't using malloc memory. Instead it uses
 		strtok allocated memory. This is never deleted, we must check this in the future to prevent memory leaks.
-	 v.0.18.4: [18/06/2017]
+
+	v.0.18.4: [18/06/2017]
 		Unterminated string hotfix. Find a better way to solve it. Probably a more flex-like fix.
-	 v.0.19.0: [15/03/2019]
+
+	v.0.19.0: [15/03/2019]
 		Completed source code translation to English.
 		Replaced WAV writing code with new working version.
 */
@@ -160,18 +164,18 @@ int maxpage[4] = {32, 64, 256, 256};
 
 struct
 {
-  char *name;
-  int value;
-  int type;
-  int page;
+	char *name;
+	int value;
+	int type;
+	int page;
 } id_list[MAX_ID];
 %}
 
 %union
 {
-  int val;
-  double real;
-  char *txt;
+	int val;
+	double real;
+	char *txt;
 }
 
 /* Main elements */
@@ -360,2557 +364,2563 @@ struct
 
 /* Grammar rules */
 
-start: /* empty */
-        | start line
+start:	/* empty */
+		| start line
 ;
 
-line:    pseudo_instruction EOL
-        | mnemo_load8bit EOL
-        | mnemo_load16bit EOL
-        | mnemo_exchange EOL
-        | mnemo_math16bit EOL
-        | mnemo_math8bit EOL
-        | mnemo_general EOL
-        | mnemo_rotate EOL
-        | mnemo_bits EOL
-        | mnemo_io EOL
-        | mnemo_jump EOL
-        | mnemo_call EOL
-        | PREPRO_FILE TEXT EOL {
-            strncpy(fname_src, $2, PATH_MAX);
-          }
-        | PREPRO_LINE value EOL {
-            lines = $2;
-          }
-        | label line
-        | label EOL
-;
-
-label: IDENTIFICATOR ':' {
-            register_label(strtok($1, ":"));
-          }
-        | LOCAL_IDENTIFICATOR ':' {
-            register_local(strtok($1, ":"));
-          }
-;
-
-pseudo_instruction: PSEUDO_ORG value {
-            if (conditional[conditional_level])
-            {
-              PC = $2;
-              ePC = PC;
-            }
-          }
-        | PSEUDO_PHASE value {
-            if (conditional[conditional_level])
-              ePC = $2;
-          }
-        | PSEUDO_DEPHASE {
-            if (conditional[conditional_level])
-              ePC = PC;
-          }
-        | PSEUDO_ROM {
-            if (conditional[conditional_level])
-              type_rom();
-          }
-        | PSEUDO_MEGAROM {
-            if (conditional[conditional_level])
-              type_megarom(0);
-          }
-        | PSEUDO_MEGAROM value {
-            if (conditional[conditional_level])
-              type_megarom($2);
-          }
-        | PSEUDO_BASIC {
-            if (conditional[conditional_level])
-              type_basic();
-          }
-        | PSEUDO_MSXDOS {
-            if (conditional[conditional_level])
-              type_msxdos();
-          }
-        | PSEUDO_SINCLAIR {
-            if (conditional[conditional_level])
-              type_sinclair();
-          }
-        | PSEUDO_BIOS {
-            if (conditional[conditional_level])
-            {
-              if (!bios)
-                msx_bios();
-            }
-          }
-        | PSEUDO_PAGE value {
-            if (conditional[conditional_level])
-            {
-              subpage = 0x100;
-              if ($2 > 3)
-                error_message(22);
-              else
-              {
-                PC = 0x4000 * $2;
-                ePC = PC;
-              }
-            }
-          }
-        | PSEUDO_SEARCH {
-            if (conditional[conditional_level])
-            {
-              if ((rom_type != MEGAROM) && (rom_type != ROM))
-                error_message(41);
-              locate_32k();
-            }
-          }
-        | PSEUDO_SUBPAGE value PSEUDO_AT value {
-            if (conditional[conditional_level])
-            {
-              if (rom_type != MEGAROM)
-                error_message(40);
-              create_subpage($2, $4);
-            }
-          }
-        | PSEUDO_SELECT value PSEUDO_AT value {
-            if (conditional[conditional_level])
-            {
-              if (rom_type != MEGAROM)
-                error_message(40);
-              select_page_direct($2, $4);
-            }
-          }
-        | PSEUDO_SELECT REGISTER PSEUDO_AT value {
-            if (conditional[conditional_level])
-            {
-              if (rom_type != MEGAROM)
-                error_message(40);
-              select_page_register($2, $4);
-            }
-          }
-        | PSEUDO_START value {
-            if (conditional[conditional_level])
-              run_address = $2;
-          }
-        | PSEUDO_CALLBIOS value {
-            if (conditional[conditional_level])
-            {
-              write_byte(0xfd);
-              write_byte(0x2a);
-              write_word(0xfcc0);
-              write_byte(0xdd);
-              write_byte(0x21);
-              write_word($2);
-              write_byte(0xcd);
-              write_word(0x001c);
-            }
-          }
-        | PSEUDO_CALLDOS value {
-            if (conditional[conditional_level])
-            {
-              if (rom_type != MSXDOS)
-                error_message(25);
-              write_byte(0x0e);
-              write_byte($2);
-              write_byte(0xcd);
-              write_word(0x0005);
-            }
-          }
-        | PSEUDO_DB list_8bits {
-            ;
-          }
-        | PSEUDO_DW list_16bits {
-            ;
-          }
-        | PSEUDO_DS value_16bits {
-            if (conditional[conditional_level])
-            {
-              if (start_address > PC)
-                start_address = PC;
-              PC += $2;
-              ePC += $2;
-              if (PC > 0xffff)
-                error_message(1);
-            }
-          }
-        | PSEUDO_BYTE {
-            if (conditional[conditional_level])
-            {
-              PC++;
-              ePC++;
-            }
-          }
-        | PSEUDO_WORD {
-            if (conditional[conditional_level])
-            {
-              PC += 2;
-              ePC += 2;
-            }
-          }
-        | IDENTIFICATOR PSEUDO_EQU value {
-            if (conditional[conditional_level])
-              register_symbol(strtok($1, "="), $3, 2);
-          }
-        | IDENTIFICATOR PSEUDO_ASSIGN value {
-            if (conditional[conditional_level])
-              register_variable(strtok($1, "="), $3);
-          }
-        | PSEUDO_INCBIN TEXT {
-            if (conditional[conditional_level])
-              include_binary($2, 0, 0);
-          }
-        | PSEUDO_INCBIN TEXT PSEUDO_SKIP value {
-            if (conditional[conditional_level])
-            {
-              if ($4 <= 0)
-                error_message(30);
-              include_binary($2, $4, 0);
-            }
-          }
-        | PSEUDO_INCBIN TEXT PSEUDO_SIZE value {
-            if (conditional[conditional_level])
-            {
-              if ($4 <= 0)
-                error_message(30);
-              include_binary($2, 0, $4);
-            }
-          }
-        | PSEUDO_INCBIN TEXT PSEUDO_SKIP value PSEUDO_SIZE value {
-            if (conditional[conditional_level])
-            {
-              if (($4 <= 0) || ($6 <= 0))
-                error_message(30);
-              include_binary($2, $4, $6);
-            }
-          }
-        | PSEUDO_INCBIN TEXT PSEUDO_SIZE value PSEUDO_SKIP value {
-            if (conditional[conditional_level])
-            {
-              if (($4 <= 0) || ($6 <= 0))
-                error_message(30);
-              include_binary($2, $6, $4);
-            }
-          }
-        | PSEUDO_END {
-            if (pass == 3)
-              finalize();
-            PC = 0;
-            ePC = 0;
-            last_global = 0;
-            rom_type = 0;
-            zilog = 0;
-            if (conditional_level)
-              error_message(45);
-          }
-        | PSEUDO_DEBUG TEXT {
-            if (conditional[conditional_level])
-            {
-              write_byte(0x52);
-              write_byte(0x18);
-              write_byte((int)(strlen($2) + 4));
-              write_string($2);
-            }
-          }
-        | PSEUDO_BREAK {
-            if (conditional[conditional_level])
-            {
-              write_byte(0x40);
-              write_byte(0x18);
-              write_byte(0x00);
-            }
-          }
-        | PSEUDO_BREAK value {
-            if (conditional[conditional_level])
-            {
-              write_byte(0x40);
-              write_byte(0x18);
-              write_byte(0x02);
-              write_word($2);
-            }
-          }
-        | PSEUDO_PRINTTEXT TEXT {
-            if (conditional[conditional_level])
-            {
-              if (pass == 2)
-              {
-                if (fmsg == NULL)
-                  create_txt();
-				if (fmsg)
-                  fprintf(fmsg, "%s\n", $2);
-              }
-            }
-          }
-        | PSEUDO_PRINT value {
-            if (conditional[conditional_level])
-            {
-              if (pass == 2)
-              {
-                if (fmsg == NULL)
-                  create_txt();
-				if (fmsg)
-                  fprintf(fmsg, "%d\n", (short int)$2 & 0xffff);
-              }
-            }
-          }
-        | PSEUDO_PRINT value_real {
-            if (conditional[conditional_level])
-            {
-              if (pass == 2)
-              {
-                if (fmsg == NULL)
-                  create_txt();
-				if (fmsg)
-                  fprintf(fmsg, "%.4f\n", $2);
-              }
-            }
-          }
-        | PSEUDO_PRINTHEX value {
-            if (conditional[conditional_level])
-            {
-              if (pass == 2)
-              {
-                if (fmsg == NULL)
-                  create_txt();
-				if (fmsg)
-                  fprintf(fmsg, "$%4.4x\n", (short int)$2 & 0xffff);
-              }
-            }
-          }
-        | PSEUDO_PRINTFIX value {
-            if (conditional[conditional_level])
-            {
-              if (pass == 2)
-              {
-                if (fmsg == NULL)
-                  create_txt();
-				if (fmsg)
-                  fprintf(fmsg, "%.4f\n", ((float)($2 & 0xffff)) / 256);
-              }
-            }
-          }
-        | PSEUDO_SIZE value {
-            if (conditional[conditional_level] && (pass == 2))
-            {
-              if (size > 0)
-                error_message(15);
-              else
-                size = $2;
-            }
-          }
-        | PSEUDO_IF value {
-            if (conditional_level == 15)
+line:	pseudo_instruction EOL
+		| mnemo_load8bit EOL
+		| mnemo_load16bit EOL
+		| mnemo_exchange EOL
+		| mnemo_math16bit EOL
+		| mnemo_math8bit EOL
+		| mnemo_general EOL
+		| mnemo_rotate EOL
+		| mnemo_bits EOL
+		| mnemo_io EOL
+		| mnemo_jump EOL
+		| mnemo_call EOL
+		| PREPRO_FILE TEXT EOL
 			{
-              error_message(44);
+				strncpy(fname_src, $2, PATH_MAX);
+			}
+		| PREPRO_LINE value EOL
+			{
+				lines = $2;
+			}
+		| label line
+		| label EOL
+;
+
+label: IDENTIFICATOR ':'
+			{
+				register_label(strtok($1, ":"));
+			}
+		| LOCAL_IDENTIFICATOR ':'
+			{
+				register_local(strtok($1, ":"));
+			}
+;
+
+pseudo_instruction: PSEUDO_ORG value
+			{
+				if (conditional[conditional_level])
+				{
+					PC = $2;
+					ePC = PC;
+				}
+			}
+		| PSEUDO_PHASE value
+			{
+      if (conditional[conditional_level])
+        ePC = $2;
+		}
+  | PSEUDO_DEPHASE {
+      if (conditional[conditional_level])
+        ePC = PC;
+    }
+  | PSEUDO_ROM {
+      if (conditional[conditional_level])
+        type_rom();
+    }
+  | PSEUDO_MEGAROM {
+      if (conditional[conditional_level])
+        type_megarom(0);
+    }
+  | PSEUDO_MEGAROM value {
+      if (conditional[conditional_level])
+        type_megarom($2);
+    }
+  | PSEUDO_BASIC {
+      if (conditional[conditional_level])
+        type_basic();
+    }
+  | PSEUDO_MSXDOS {
+      if (conditional[conditional_level])
+        type_msxdos();
+    }
+  | PSEUDO_SINCLAIR {
+      if (conditional[conditional_level])
+        type_sinclair();
+    }
+  | PSEUDO_BIOS {
+      if (conditional[conditional_level])
+      {
+        if (!bios)
+    msx_bios();
+      }
+    }
+  | PSEUDO_PAGE value {
+      if (conditional[conditional_level])
+      {
+        subpage = 0x100;
+        if ($2 > 3)
+    error_message(22);
+        else
+        {
+    PC = 0x4000 * $2;
+    ePC = PC;
+        }
+      }
+    }
+  | PSEUDO_SEARCH {
+      if (conditional[conditional_level])
+      {
+        if ((rom_type != MEGAROM) && (rom_type != ROM))
+    error_message(41);
+        locate_32k();
+      }
+    }
+  | PSEUDO_SUBPAGE value PSEUDO_AT value {
+      if (conditional[conditional_level])
+      {
+        if (rom_type != MEGAROM)
+    error_message(40);
+        create_subpage($2, $4);
+      }
+    }
+  | PSEUDO_SELECT value PSEUDO_AT value {
+      if (conditional[conditional_level])
+      {
+        if (rom_type != MEGAROM)
+    error_message(40);
+        select_page_direct($2, $4);
+      }
+    }
+  | PSEUDO_SELECT REGISTER PSEUDO_AT value {
+      if (conditional[conditional_level])
+      {
+        if (rom_type != MEGAROM)
+    error_message(40);
+        select_page_register($2, $4);
+      }
+    }
+  | PSEUDO_START value {
+      if (conditional[conditional_level])
+        run_address = $2;
+    }
+  | PSEUDO_CALLBIOS value {
+      if (conditional[conditional_level])
+      {
+        write_byte(0xfd);
+        write_byte(0x2a);
+        write_word(0xfcc0);
+        write_byte(0xdd);
+        write_byte(0x21);
+        write_word($2);
+        write_byte(0xcd);
+        write_word(0x001c);
+      }
+    }
+  | PSEUDO_CALLDOS value {
+      if (conditional[conditional_level])
+      {
+        if (rom_type != MSXDOS)
+    error_message(25);
+        write_byte(0x0e);
+        write_byte($2);
+        write_byte(0xcd);
+        write_word(0x0005);
+      }
+    }
+  | PSEUDO_DB list_8bits {
+      ;
+    }
+  | PSEUDO_DW list_16bits {
+      ;
+    }
+  | PSEUDO_DS value_16bits {
+      if (conditional[conditional_level])
+      {
+        if (start_address > PC)
+    start_address = PC;
+        PC += $2;
+        ePC += $2;
+        if (PC > 0xffff)
+    error_message(1);
+      }
+    }
+  | PSEUDO_BYTE {
+      if (conditional[conditional_level])
+      {
+        PC++;
+        ePC++;
+      }
+    }
+  | PSEUDO_WORD {
+      if (conditional[conditional_level])
+      {
+        PC += 2;
+        ePC += 2;
+      }
+    }
+  | IDENTIFICATOR PSEUDO_EQU value {
+      if (conditional[conditional_level])
+        register_symbol(strtok($1, "="), $3, 2);
+    }
+  | IDENTIFICATOR PSEUDO_ASSIGN value {
+      if (conditional[conditional_level])
+        register_variable(strtok($1, "="), $3);
+    }
+  | PSEUDO_INCBIN TEXT {
+      if (conditional[conditional_level])
+        include_binary($2, 0, 0);
+    }
+  | PSEUDO_INCBIN TEXT PSEUDO_SKIP value {
+      if (conditional[conditional_level])
+      {
+        if ($4 <= 0)
+    error_message(30);
+        include_binary($2, $4, 0);
+      }
+    }
+  | PSEUDO_INCBIN TEXT PSEUDO_SIZE value {
+      if (conditional[conditional_level])
+      {
+        if ($4 <= 0)
+    error_message(30);
+        include_binary($2, 0, $4);
+      }
+    }
+  | PSEUDO_INCBIN TEXT PSEUDO_SKIP value PSEUDO_SIZE value {
+      if (conditional[conditional_level])
+      {
+        if (($4 <= 0) || ($6 <= 0))
+    error_message(30);
+        include_binary($2, $4, $6);
+      }
+    }
+  | PSEUDO_INCBIN TEXT PSEUDO_SIZE value PSEUDO_SKIP value {
+      if (conditional[conditional_level])
+      {
+        if (($4 <= 0) || ($6 <= 0))
+    error_message(30);
+        include_binary($2, $6, $4);
+      }
+    }
+  | PSEUDO_END {
+      if (pass == 3)
+        finalize();
+      PC = 0;
+      ePC = 0;
+      last_global = 0;
+      rom_type = 0;
+      zilog = 0;
+      if (conditional_level)
+        error_message(45);
+    }
+  | PSEUDO_DEBUG TEXT {
+      if (conditional[conditional_level])
+      {
+        write_byte(0x52);
+        write_byte(0x18);
+        write_byte((int)(strlen($2) + 4));
+        write_string($2);
+      }
+    }
+  | PSEUDO_BREAK {
+      if (conditional[conditional_level])
+      {
+        write_byte(0x40);
+        write_byte(0x18);
+        write_byte(0x00);
+      }
+    }
+  | PSEUDO_BREAK value {
+      if (conditional[conditional_level])
+      {
+        write_byte(0x40);
+        write_byte(0x18);
+        write_byte(0x02);
+        write_word($2);
+      }
+    }
+  | PSEUDO_PRINTTEXT TEXT {
+      if (conditional[conditional_level])
+      {
+        if (pass == 2)
+        {
+    if (fmsg == NULL)
+      create_txt();
+				if (fmsg)
+      fprintf(fmsg, "%s\n", $2);
+        }
+      }
+    }
+  | PSEUDO_PRINT value {
+      if (conditional[conditional_level])
+      {
+        if (pass == 2)
+        {
+    if (fmsg == NULL)
+      create_txt();
+				if (fmsg)
+      fprintf(fmsg, "%d\n", (short int)$2 & 0xffff);
+        }
+      }
+    }
+  | PSEUDO_PRINT value_real {
+      if (conditional[conditional_level])
+      {
+        if (pass == 2)
+        {
+    if (fmsg == NULL)
+      create_txt();
+				if (fmsg)
+      fprintf(fmsg, "%.4f\n", $2);
+        }
+      }
+    }
+  | PSEUDO_PRINTHEX value {
+      if (conditional[conditional_level])
+      {
+        if (pass == 2)
+        {
+    if (fmsg == NULL)
+      create_txt();
+				if (fmsg)
+      fprintf(fmsg, "$%4.4x\n", (short int)$2 & 0xffff);
+        }
+      }
+    }
+  | PSEUDO_PRINTFIX value {
+      if (conditional[conditional_level])
+      {
+        if (pass == 2)
+        {
+    if (fmsg == NULL)
+      create_txt();
+				if (fmsg)
+      fprintf(fmsg, "%.4f\n", ((float)($2 & 0xffff)) / 256);
+        }
+      }
+    }
+  | PSEUDO_SIZE value {
+      if (conditional[conditional_level] && (pass == 2))
+      {
+        if (size > 0)
+    error_message(15);
+        else
+    size = $2;
+      }
+    }
+  | PSEUDO_IF value {
+      if (conditional_level == 15)
+			{
+        error_message(44);
 			  exit(1);	/* this is to stop code analyzer warning about conditional[] buffer overrun */
 			}
-            conditional_level++;
-            if ($2)
-              conditional[conditional_level] = 1 & conditional[conditional_level - 1];
-            else
-              conditional[conditional_level] = 0;
-          }
-        | PSEUDO_IFDEF IDENTIFICATOR {
-            if (conditional_level == 15)
+      conditional_level++;
+      if ($2)
+        conditional[conditional_level] = 1 & conditional[conditional_level - 1];
+      else
+        conditional[conditional_level] = 0;
+    }
+  | PSEUDO_IFDEF IDENTIFICATOR {
+      if (conditional_level == 15)
 			{
-              error_message(44);
+        error_message(44);
 			  exit(1);	/* this is to stop code analyzer warning about conditional[] buffer overrun */
 			}
-            conditional_level++;
-            if (is_defined_symbol($2))
-              conditional[conditional_level] = 1 & conditional[conditional_level - 1];
-            else
-              conditional[conditional_level] = 0;
-          }
-        | PSEUDO_ELSE {
-            if (!conditional_level)
-              error_message(42);
-            conditional[conditional_level] = (conditional[conditional_level] ^ 1) & conditional[conditional_level - 1];
-          }
-        | PSEUDO_ENDIF {
-            if (!conditional_level)
-              error_message(43);
-            conditional_level--;
-          }
-        | PSEUDO_CASSETTE TEXT {
-            if (conditional[conditional_level])
-            {
-              if (!fname_msx[0])
-                strncpy(fname_msx, $2, PATH_MAX);
-              cassette |= $1;
-            }
-          }
-        | PSEUDO_CASSETTE {
-            if (conditional[conditional_level])
-            {
-              if (!fname_msx[0])
-              {
-                strncpy(fname_msx, fname_bin, PATH_MAX);
-                fname_msx[strlen(fname_msx) - 1] = 0;
-              }
-              cassette |= $1;
-            }
-          }
-        | PSEUDO_ZILOG {
-            zilog = 1;
-          }
-        | PSEUDO_FILENAME TEXT {
-            strncpy(fname_no_ext, $2, PATH_MAX);
-          }
+      conditional_level++;
+      if (is_defined_symbol($2))
+        conditional[conditional_level] = 1 & conditional[conditional_level - 1];
+      else
+        conditional[conditional_level] = 0;
+    }
+  | PSEUDO_ELSE {
+      if (!conditional_level)
+        error_message(42);
+      conditional[conditional_level] = (conditional[conditional_level] ^ 1) & conditional[conditional_level - 1];
+    }
+  | PSEUDO_ENDIF {
+      if (!conditional_level)
+        error_message(43);
+      conditional_level--;
+    }
+  | PSEUDO_CASSETTE TEXT {
+      if (conditional[conditional_level])
+      {
+        if (!fname_msx[0])
+    strncpy(fname_msx, $2, PATH_MAX);
+        cassette |= $1;
+      }
+    }
+  | PSEUDO_CASSETTE {
+      if (conditional[conditional_level])
+      {
+        if (!fname_msx[0])
+        {
+    strncpy(fname_msx, fname_bin, PATH_MAX);
+    fname_msx[strlen(fname_msx) - 1] = 0;
+        }
+        cassette |= $1;
+      }
+    }
+  | PSEUDO_ZILOG {
+      zilog = 1;
+    }
+  | PSEUDO_FILENAME TEXT {
+      strncpy(fname_no_ext, $2, PATH_MAX);
+    }
 ;
 
 indirect_IX: '[' REGISTER_16_IX ']' {
-            $$ = 0;
-          }
+      $$ = 0;
+    }
 	| '[' REGISTER_16_IX '+' value_8bits ']' {
-            $$ = $4;
-          }
+      $$ = $4;
+    }
 	| '[' REGISTER_16_IX '-' value_8bits ']' {
-            $$ = -$4;
-          }
+      $$ = -$4;
+    }
 ;
 	
 indirect_IY: '[' REGISTER_16_IY ']' {
-            $$ = 0;
-          }
+      $$ = 0;
+    }
 	| '[' REGISTER_16_IY '+' value_8bits ']' {
-            $$ = $4;
-          }
+      $$ = $4;
+    }
 	| '[' REGISTER_16_IY '-' value_8bits ']' {
-            $$ = -$4;
-          }
+      $$ = -$4;
+    }
 ;
 	
 mnemo_load8bit: MNEMO_LD REGISTER ',' REGISTER {
-            write_byte(0x40 | ($2 << 3) | $4);
-          }
-        | MNEMO_LD REGISTER ',' REGISTER_IX {
-            if (($2 > 3) && ($2 != 7))
-              error_message(2);
-            write_byte(0xdd);
-            write_byte(0x40 | ($2 << 3) | $4);
-          }
-        | MNEMO_LD REGISTER_IX ',' REGISTER {
-            if (($4 > 3) && ($4 != 7))
-              error_message(2);
-            write_byte(0xdd);
-            write_byte(0x40 | ($2 << 3) | $4);
-          }
-        | MNEMO_LD REGISTER_IX ',' REGISTER_IX {
-            write_byte(0xdd);
-            write_byte(0x40 | ($2 << 3) | $4);
-          }
-        | MNEMO_LD REGISTER ',' REGISTER_IY {
-            if (($2 > 3) && ($2 != 7))
-              error_message(2);
-            write_byte(0xfd);
-            write_byte(0x40 | ($2 << 3) | $4);
-          }
-        | MNEMO_LD REGISTER_IY ',' REGISTER {
-            if (($4 > 3) && ($4 != 7))
-              error_message(2);
-            write_byte(0xfd);
-            write_byte(0x40 | ($2 << 3) | $4);
-          }
-        | MNEMO_LD REGISTER_IY ',' REGISTER_IY {
-            write_byte(0xfd);
-            write_byte(0x40 | ($2 << 3) | $4);
-          }
-        | MNEMO_LD REGISTER ',' value_8bits {
-            write_byte(0x06 | ($2 << 3));
-            write_byte($4);
-          }
-        | MNEMO_LD REGISTER_IX ',' value_8bits {
-            write_byte(0xdd);
-            write_byte(0x06 | ($2 << 3));
-            write_byte($4);
-          }
-        | MNEMO_LD REGISTER_IY ',' value_8bits {
-            write_byte(0xfd);
-            write_byte(0x06 | ($2 << 3));
-            write_byte($4);
-          }
-        | MNEMO_LD REGISTER ',' REGISTER_IND_HL {
-            write_byte(0x46 | ($2 << 3));
-          }
-        | MNEMO_LD REGISTER ',' indirect_IX {
-            write_byte(0xdd);
-            write_byte(0x46 | ($2 << 3));
-            write_byte($4);
-          }
-        | MNEMO_LD REGISTER ',' indirect_IY {
-            write_byte(0xfd);
-            write_byte(0x46 | ($2 << 3));
-            write_byte($4);
-          }
-        | MNEMO_LD REGISTER_IND_HL ',' REGISTER {
-            write_byte(0x70 | $4);
-          }
-        | MNEMO_LD indirect_IX ',' REGISTER {
-            write_byte(0xdd);
-            write_byte(0x70 | $4);
-            write_byte($2);
-          }
-        | MNEMO_LD indirect_IY ',' REGISTER {
-            write_byte(0xfd);
-            write_byte(0x70 | $4);
-            write_byte($2);
-          }
-        | MNEMO_LD REGISTER_IND_HL ',' value_8bits {
-            write_byte(0x36);
-            write_byte($4);
-          }
-        | MNEMO_LD indirect_IX ',' value_8bits {
-            write_byte(0xdd);
-            write_byte(0x36);
-            write_byte($2);
-            write_byte($4);
-          }
-        | MNEMO_LD indirect_IY ',' value_8bits {
-            write_byte(0xfd);
-            write_byte(0x36);
-            write_byte($2);
-            write_byte($4);
-          }
-        | MNEMO_LD REGISTER ',' REGISTER_IND_BC {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0x0a);
-          }
-        | MNEMO_LD REGISTER ',' REGISTER_IND_DE {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0x1a);
-          }
-        | MNEMO_LD REGISTER ',' '[' value_16bits ']' {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0x3a);
-            write_word($5);
-          }
-        | MNEMO_LD REGISTER_IND_BC ',' REGISTER {
-            if ($4 != 7)
-              error_message(5);
-            write_byte(0x02);
-          }
-        | MNEMO_LD REGISTER_IND_DE ',' REGISTER {
-            if ($4 != 7)
-              error_message(5);
-            write_byte(0x12);
-          }
-        | MNEMO_LD '[' value_16bits ']' ',' REGISTER {
-            if ($6 != 7)
-              error_message(5);
-            write_byte(0x32);
-            write_word($3);
-          }
-        | MNEMO_LD REGISTER ',' REGISTER_I {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xed);
-            write_byte(0x57);
-          }
-        | MNEMO_LD REGISTER ',' REGISTER_R {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xed);
-            write_byte(0x5f);
-          }
-        | MNEMO_LD REGISTER_I ',' REGISTER {
-            if ($4 != 7)
-              error_message(5);
-            write_byte(0xed);
-            write_byte(0x47);
-          }
-        | MNEMO_LD REGISTER_R ',' REGISTER {
-            if ($4 != 7)
-              error_message(5);
-            write_byte(0xed);
-            write_byte(0x4f);
-          }
+      write_byte(0x40 | ($2 << 3) | $4);
+    }
+  | MNEMO_LD REGISTER ',' REGISTER_IX {
+      if (($2 > 3) && ($2 != 7))
+        error_message(2);
+      write_byte(0xdd);
+      write_byte(0x40 | ($2 << 3) | $4);
+    }
+  | MNEMO_LD REGISTER_IX ',' REGISTER {
+      if (($4 > 3) && ($4 != 7))
+        error_message(2);
+      write_byte(0xdd);
+      write_byte(0x40 | ($2 << 3) | $4);
+    }
+  | MNEMO_LD REGISTER_IX ',' REGISTER_IX {
+      write_byte(0xdd);
+      write_byte(0x40 | ($2 << 3) | $4);
+    }
+  | MNEMO_LD REGISTER ',' REGISTER_IY {
+      if (($2 > 3) && ($2 != 7))
+        error_message(2);
+      write_byte(0xfd);
+      write_byte(0x40 | ($2 << 3) | $4);
+    }
+  | MNEMO_LD REGISTER_IY ',' REGISTER {
+      if (($4 > 3) && ($4 != 7))
+        error_message(2);
+      write_byte(0xfd);
+      write_byte(0x40 | ($2 << 3) | $4);
+    }
+  | MNEMO_LD REGISTER_IY ',' REGISTER_IY {
+      write_byte(0xfd);
+      write_byte(0x40 | ($2 << 3) | $4);
+    }
+  | MNEMO_LD REGISTER ',' value_8bits {
+      write_byte(0x06 | ($2 << 3));
+      write_byte($4);
+    }
+  | MNEMO_LD REGISTER_IX ',' value_8bits {
+      write_byte(0xdd);
+      write_byte(0x06 | ($2 << 3));
+      write_byte($4);
+    }
+  | MNEMO_LD REGISTER_IY ',' value_8bits {
+      write_byte(0xfd);
+      write_byte(0x06 | ($2 << 3));
+      write_byte($4);
+    }
+  | MNEMO_LD REGISTER ',' REGISTER_IND_HL {
+      write_byte(0x46 | ($2 << 3));
+    }
+  | MNEMO_LD REGISTER ',' indirect_IX {
+      write_byte(0xdd);
+      write_byte(0x46 | ($2 << 3));
+      write_byte($4);
+    }
+  | MNEMO_LD REGISTER ',' indirect_IY {
+      write_byte(0xfd);
+      write_byte(0x46 | ($2 << 3));
+      write_byte($4);
+    }
+  | MNEMO_LD REGISTER_IND_HL ',' REGISTER {
+      write_byte(0x70 | $4);
+    }
+  | MNEMO_LD indirect_IX ',' REGISTER {
+      write_byte(0xdd);
+      write_byte(0x70 | $4);
+      write_byte($2);
+    }
+  | MNEMO_LD indirect_IY ',' REGISTER {
+      write_byte(0xfd);
+      write_byte(0x70 | $4);
+      write_byte($2);
+    }
+  | MNEMO_LD REGISTER_IND_HL ',' value_8bits {
+      write_byte(0x36);
+      write_byte($4);
+    }
+  | MNEMO_LD indirect_IX ',' value_8bits {
+      write_byte(0xdd);
+      write_byte(0x36);
+      write_byte($2);
+      write_byte($4);
+    }
+  | MNEMO_LD indirect_IY ',' value_8bits {
+      write_byte(0xfd);
+      write_byte(0x36);
+      write_byte($2);
+      write_byte($4);
+    }
+  | MNEMO_LD REGISTER ',' REGISTER_IND_BC {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0x0a);
+    }
+  | MNEMO_LD REGISTER ',' REGISTER_IND_DE {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0x1a);
+    }
+  | MNEMO_LD REGISTER ',' '[' value_16bits ']' {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0x3a);
+      write_word($5);
+    }
+  | MNEMO_LD REGISTER_IND_BC ',' REGISTER {
+      if ($4 != 7)
+        error_message(5);
+      write_byte(0x02);
+    }
+  | MNEMO_LD REGISTER_IND_DE ',' REGISTER {
+      if ($4 != 7)
+        error_message(5);
+      write_byte(0x12);
+    }
+  | MNEMO_LD '[' value_16bits ']' ',' REGISTER {
+      if ($6 != 7)
+        error_message(5);
+      write_byte(0x32);
+      write_word($3);
+    }
+  | MNEMO_LD REGISTER ',' REGISTER_I {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xed);
+      write_byte(0x57);
+    }
+  | MNEMO_LD REGISTER ',' REGISTER_R {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xed);
+      write_byte(0x5f);
+    }
+  | MNEMO_LD REGISTER_I ',' REGISTER {
+      if ($4 != 7)
+        error_message(5);
+      write_byte(0xed);
+      write_byte(0x47);
+    }
+  | MNEMO_LD REGISTER_R ',' REGISTER {
+      if ($4 != 7)
+        error_message(5);
+      write_byte(0xed);
+      write_byte(0x4f);
+    }
 ;
 
 mnemo_load16bit: MNEMO_LD REGISTER_PAIR ',' value_16bits {
-            write_byte(0x01 | ($2 << 4));
-            write_word($4);
-          }
-        | MNEMO_LD REGISTER_16_IX ',' value_16bits {
-            write_byte(0xdd);
-            write_byte(0x21);
-            write_word($4);
-          }
-        | MNEMO_LD REGISTER_16_IY ',' value_16bits {
-            write_byte(0xfd);
-            write_byte(0x21);
-            write_word($4);
-          }
-        | MNEMO_LD REGISTER_PAIR ',' '[' value_16bits ']' {
-            if ($2 != 2)
-            {
-              write_byte(0xed);
-              write_byte(0x4b | ($2 << 4));
-            }
-            else 
-              write_byte(0x2a);
-            write_word($5);
-          }
-        | MNEMO_LD REGISTER_16_IX ',' '[' value_16bits ']' {
-            write_byte(0xdd);
-            write_byte(0x2a);
-            write_word($5);
-          }
-        | MNEMO_LD REGISTER_16_IY ',' '[' value_16bits ']' {
-            write_byte(0xfd);
-            write_byte(0x2a);
-            write_word($5);
-          }
-        | MNEMO_LD '[' value_16bits ']' ',' REGISTER_PAIR {
-            if ($6 != 2)
-            {
-              write_byte(0xed);
-              write_byte(0x43 | ($6 << 4));
-            }
-            else
-              write_byte(0x22);
-            write_word($3);
-          }
-        | MNEMO_LD '[' value_16bits ']' ',' REGISTER_16_IX {
-            write_byte(0xdd);
-            write_byte(0x22);
-            write_word($3);
-          }
-        | MNEMO_LD '[' value_16bits ']' ',' REGISTER_16_IY {
-            write_byte(0xfd);
-            write_byte(0x22);
-            write_word($3);
-          }
-        | MNEMO_LD_SP ',' '[' value_16bits ']' {
-            write_byte(0xed);
-            write_byte(0x7b);
-            write_word($4);
-          }
-        | MNEMO_LD_SP ',' value_16bits {
-            write_byte(0x31);
-            write_word($3);
-          }
-        | MNEMO_LD_SP ',' REGISTER_PAIR {
-            if ($3 != 2)
-              error_message(2);
-            write_byte(0xf9);
-          }
-        | MNEMO_LD_SP ',' REGISTER_16_IX {
-            write_byte(0xdd);
-            write_byte(0xf9);
-          }
-        | MNEMO_LD_SP ',' REGISTER_16_IY {
-            write_byte(0xfd);
-            write_byte(0xf9);
-          }
-        | MNEMO_PUSH REGISTER_PAIR {
-            if ($2 == 3)
-              error_message(2);
-            write_byte(0xc5 | ($2 << 4));
-          }
-        | MNEMO_PUSH REGISTER_AF {
-            write_byte(0xf5);
-          }
-        | MNEMO_PUSH REGISTER_16_IX {
-            write_byte(0xdd);
-            write_byte(0xe5);
-          }
-        | MNEMO_PUSH REGISTER_16_IY {
-            write_byte(0xfd);
-            write_byte(0xe5);
-          }
-        | MNEMO_POP REGISTER_PAIR {
-            if ($2 == 3)
-              error_message(2);
-            write_byte(0xc1 | ($2 << 4));
-          }
-        | MNEMO_POP REGISTER_AF {
-            write_byte(0xf1);
-          }
-        | MNEMO_POP REGISTER_16_IX {
-            write_byte(0xdd);
-            write_byte(0xe1);
-          }
-        | MNEMO_POP REGISTER_16_IY {
-            write_byte(0xfd);
-            write_byte(0xe1);
-          }
+      write_byte(0x01 | ($2 << 4));
+      write_word($4);
+    }
+  | MNEMO_LD REGISTER_16_IX ',' value_16bits {
+      write_byte(0xdd);
+      write_byte(0x21);
+      write_word($4);
+    }
+  | MNEMO_LD REGISTER_16_IY ',' value_16bits {
+      write_byte(0xfd);
+      write_byte(0x21);
+      write_word($4);
+    }
+  | MNEMO_LD REGISTER_PAIR ',' '[' value_16bits ']' {
+      if ($2 != 2)
+      {
+        write_byte(0xed);
+        write_byte(0x4b | ($2 << 4));
+      }
+      else 
+        write_byte(0x2a);
+      write_word($5);
+    }
+  | MNEMO_LD REGISTER_16_IX ',' '[' value_16bits ']' {
+      write_byte(0xdd);
+      write_byte(0x2a);
+      write_word($5);
+    }
+  | MNEMO_LD REGISTER_16_IY ',' '[' value_16bits ']' {
+      write_byte(0xfd);
+      write_byte(0x2a);
+      write_word($5);
+    }
+  | MNEMO_LD '[' value_16bits ']' ',' REGISTER_PAIR {
+      if ($6 != 2)
+      {
+        write_byte(0xed);
+        write_byte(0x43 | ($6 << 4));
+      }
+      else
+        write_byte(0x22);
+      write_word($3);
+    }
+  | MNEMO_LD '[' value_16bits ']' ',' REGISTER_16_IX {
+      write_byte(0xdd);
+      write_byte(0x22);
+      write_word($3);
+    }
+  | MNEMO_LD '[' value_16bits ']' ',' REGISTER_16_IY {
+      write_byte(0xfd);
+      write_byte(0x22);
+      write_word($3);
+    }
+  | MNEMO_LD_SP ',' '[' value_16bits ']' {
+      write_byte(0xed);
+      write_byte(0x7b);
+      write_word($4);
+    }
+  | MNEMO_LD_SP ',' value_16bits {
+      write_byte(0x31);
+      write_word($3);
+    }
+  | MNEMO_LD_SP ',' REGISTER_PAIR {
+      if ($3 != 2)
+        error_message(2);
+      write_byte(0xf9);
+    }
+  | MNEMO_LD_SP ',' REGISTER_16_IX {
+      write_byte(0xdd);
+      write_byte(0xf9);
+    }
+  | MNEMO_LD_SP ',' REGISTER_16_IY {
+      write_byte(0xfd);
+      write_byte(0xf9);
+    }
+  | MNEMO_PUSH REGISTER_PAIR {
+      if ($2 == 3)
+        error_message(2);
+      write_byte(0xc5 | ($2 << 4));
+    }
+  | MNEMO_PUSH REGISTER_AF {
+      write_byte(0xf5);
+    }
+  | MNEMO_PUSH REGISTER_16_IX {
+      write_byte(0xdd);
+      write_byte(0xe5);
+    }
+  | MNEMO_PUSH REGISTER_16_IY {
+      write_byte(0xfd);
+      write_byte(0xe5);
+    }
+  | MNEMO_POP REGISTER_PAIR {
+      if ($2 == 3)
+        error_message(2);
+      write_byte(0xc1 | ($2 << 4));
+    }
+  | MNEMO_POP REGISTER_AF {
+      write_byte(0xf1);
+    }
+  | MNEMO_POP REGISTER_16_IX {
+      write_byte(0xdd);
+      write_byte(0xe1);
+    }
+  | MNEMO_POP REGISTER_16_IY {
+      write_byte(0xfd);
+      write_byte(0xe1);
+    }
 ;
 
 mnemo_exchange: MNEMO_EX REGISTER_PAIR ',' REGISTER_PAIR {
-            if ((($2 != 1) || ($4 != 2)) && (($2 != 2) || ($4 != 1)))
-              error_message(2);
-            if (zilog && ($2 != 1))
-              warning_message(5);
-            write_byte(0xeb);
-          }
-        | MNEMO_EX REGISTER_AF ',' REGISTER_AF APOSTROPHE {
-            write_byte(0x08);
-          }
-        | MNEMO_EXX {
-            write_byte(0xd9);
-          }
-        | MNEMO_EX REGISTER_IND_SP ',' REGISTER_PAIR {
-            if ($4 != 2)
-              error_message(2);
-            write_byte(0xe3);
-          }
-        | MNEMO_EX REGISTER_IND_SP ',' REGISTER_16_IX {
-            write_byte(0xdd);
-            write_byte(0xe3);
-          }
-        | MNEMO_EX REGISTER_IND_SP ',' REGISTER_16_IY {
-            write_byte(0xfd);
-            write_byte(0xe3);
-          }
-        | MNEMO_LDI {
-            write_byte(0xed);
-            write_byte(0xa0);
-          }
-        | MNEMO_LDIR {
-            write_byte(0xed);
-            write_byte(0xb0);
-          }
-        | MNEMO_LDD {
-            write_byte(0xed);
-            write_byte(0xa8);
-          }
-        | MNEMO_LDDR {
-            write_byte(0xed);
-            write_byte(0xb8);
-          }
-        | MNEMO_CPI {
-            write_byte(0xed);
-            write_byte(0xa1);
-          }
-        | MNEMO_CPIR {
-            write_byte(0xed);
-            write_byte(0xb1);
-          }
-        | MNEMO_CPD {
-            write_byte(0xed);
-            write_byte(0xa9);
-          }
-        | MNEMO_CPDR {
-            write_byte(0xed);
-            write_byte(0xb9);
-          }
+      if ((($2 != 1) || ($4 != 2)) && (($2 != 2) || ($4 != 1)))
+        error_message(2);
+      if (zilog && ($2 != 1))
+        warning_message(5);
+      write_byte(0xeb);
+    }
+  | MNEMO_EX REGISTER_AF ',' REGISTER_AF APOSTROPHE {
+      write_byte(0x08);
+    }
+  | MNEMO_EXX {
+      write_byte(0xd9);
+    }
+  | MNEMO_EX REGISTER_IND_SP ',' REGISTER_PAIR {
+      if ($4 != 2)
+        error_message(2);
+      write_byte(0xe3);
+    }
+  | MNEMO_EX REGISTER_IND_SP ',' REGISTER_16_IX {
+      write_byte(0xdd);
+      write_byte(0xe3);
+    }
+  | MNEMO_EX REGISTER_IND_SP ',' REGISTER_16_IY {
+      write_byte(0xfd);
+      write_byte(0xe3);
+    }
+  | MNEMO_LDI {
+      write_byte(0xed);
+      write_byte(0xa0);
+    }
+  | MNEMO_LDIR {
+      write_byte(0xed);
+      write_byte(0xb0);
+    }
+  | MNEMO_LDD {
+      write_byte(0xed);
+      write_byte(0xa8);
+    }
+  | MNEMO_LDDR {
+      write_byte(0xed);
+      write_byte(0xb8);
+    }
+  | MNEMO_CPI {
+      write_byte(0xed);
+      write_byte(0xa1);
+    }
+  | MNEMO_CPIR {
+      write_byte(0xed);
+      write_byte(0xb1);
+    }
+  | MNEMO_CPD {
+      write_byte(0xed);
+      write_byte(0xa9);
+    }
+  | MNEMO_CPDR {
+      write_byte(0xed);
+      write_byte(0xb9);
+    }
 ;
 
 mnemo_math8bit: MNEMO_ADD REGISTER ',' REGISTER {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0x80|$4);
-          }
-        | MNEMO_ADD REGISTER ',' REGISTER_IX {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xdd);
-            write_byte(0x80 | $4);
-          }
-        | MNEMO_ADD REGISTER ',' REGISTER_IY {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xfd);
-            write_byte(0x80 | $4);
-          }
-        | MNEMO_ADD REGISTER ',' value_8bits {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xc6);
-            write_byte($4);
-          }
-        | MNEMO_ADD REGISTER ',' REGISTER_IND_HL {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0x86);
-          }
-        | MNEMO_ADD REGISTER ',' indirect_IX {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xdd);
-            write_byte(0x86);
-            write_byte($4);
-          }
-        | MNEMO_ADD REGISTER ',' indirect_IY {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xfd);
-            write_byte(0x86);
-            write_byte($4);
-          }
-        | MNEMO_ADC REGISTER ',' REGISTER {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0x88 | $4);
-          }
-        | MNEMO_ADC REGISTER ',' REGISTER_IX {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xdd);
-            write_byte(0x88 | $4);
-          }
-        | MNEMO_ADC REGISTER ',' REGISTER_IY {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xfd);
-            write_byte(0x88 | $4);
-          }
-        | MNEMO_ADC REGISTER ',' value_8bits {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xce);
-            write_byte($4);
-          }
-        | MNEMO_ADC REGISTER ',' REGISTER_IND_HL {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0x8e);
-          }
-        | MNEMO_ADC REGISTER ',' indirect_IX {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xdd);
-            write_byte(0x8e);
-            write_byte($4);
-          }
-        | MNEMO_ADC REGISTER ',' indirect_IY {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xfd);
-            write_byte(0x8e);
-            write_byte($4);
-          }
-        | MNEMO_SUB REGISTER ',' REGISTER {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0x90 | $4);
-          }
-        | MNEMO_SUB REGISTER ',' REGISTER_IX {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdd);
-            write_byte(0x90 | $4);
-          }
-        | MNEMO_SUB REGISTER ',' REGISTER_IY {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xfd);
-            write_byte(0x90 | $4);
-          }
-        | MNEMO_SUB REGISTER ',' value_8bits {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xd6);
-            write_byte($4);
-          }
-        | MNEMO_SUB REGISTER ',' REGISTER_IND_HL {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0x96);
-          }
-        | MNEMO_SUB REGISTER ',' indirect_IX {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdd);
-            write_byte(0x96);
-            write_byte($4);
-          }
-        | MNEMO_SUB REGISTER ',' indirect_IY {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xfd);
-            write_byte(0x96);
-            write_byte($4);
-          }
-        | MNEMO_SBC REGISTER ',' REGISTER {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0x98 | $4);
-          }
-        | MNEMO_SBC REGISTER ',' REGISTER_IX {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xdd);
-            write_byte(0x98 | $4);
-          }
-        | MNEMO_SBC REGISTER ',' REGISTER_IY {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xfd);
-            write_byte(0x98 | $4);
-          }
-        | MNEMO_SBC REGISTER ',' value_8bits {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xde);
-            write_byte($4);
-          }
-        | MNEMO_SBC REGISTER ',' REGISTER_IND_HL {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0x9e);
-          }
-        | MNEMO_SBC REGISTER ',' indirect_IX {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xdd);
-            write_byte(0x9e);
-            write_byte($4);
-          }
-        | MNEMO_SBC REGISTER ',' indirect_IY {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xfd);
-            write_byte(0x9e);
-            write_byte($4);
-          }
-        | MNEMO_AND REGISTER ',' REGISTER {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xa0 | $4);
-          }
-        | MNEMO_AND REGISTER ',' REGISTER_IX {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdd);
-            write_byte(0xa0 | $4);
-          }
-        | MNEMO_AND REGISTER ',' REGISTER_IY {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xfd);
-            write_byte(0xa0 | $4);
-          }
-        | MNEMO_AND REGISTER ',' value_8bits {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xe6);
-            write_byte($4);
-          }
-        | MNEMO_AND REGISTER ',' REGISTER_IND_HL {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xa6);
-          }
-        | MNEMO_AND REGISTER ',' indirect_IX {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdd);
-            write_byte(0xa6);
-            write_byte($4);
-          }
-        | MNEMO_AND REGISTER ',' indirect_IY {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xfd);
-            write_byte(0xa6);
-            write_byte($4);
-          }
-        | MNEMO_OR REGISTER ',' REGISTER {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xb0 | $4);
-          }
-        | MNEMO_OR REGISTER ',' REGISTER_IX {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog) 
-              warning_message(5);
-            write_byte(0xdd);
-            write_byte(0xb0 | $4);
-          }
-        | MNEMO_OR REGISTER ',' REGISTER_IY {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xfd);
-            write_byte(0xb0 | $4);
-          }
-        | MNEMO_OR REGISTER ',' value_8bits {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xf6);
-            write_byte($4);
-          }
-        | MNEMO_OR REGISTER ',' REGISTER_IND_HL {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xb6);
-          }
-        | MNEMO_OR REGISTER ',' indirect_IX {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdd);
-            write_byte(0xb6);
-            write_byte($4);
-          }
-        | MNEMO_OR REGISTER ',' indirect_IY {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xfd);
-            write_byte(0xb6);
-            write_byte($4);
-          }
-        | MNEMO_XOR REGISTER ',' REGISTER {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xa8 | $4);
-          }
-        | MNEMO_XOR REGISTER ',' REGISTER_IX {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdd);
-            write_byte(0xa8 | $4);
-          }
-        | MNEMO_XOR REGISTER ',' REGISTER_IY {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xfd);
-            write_byte(0xa8 | $4);
-          }
-        | MNEMO_XOR REGISTER ',' value_8bits {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xee);
-            write_byte($4);
-          }
-        | MNEMO_XOR REGISTER ',' REGISTER_IND_HL {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xae);
-          }
-        | MNEMO_XOR REGISTER ',' indirect_IX {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdd);
-            write_byte(0xae);
-            write_byte($4);
-          }
-        | MNEMO_XOR REGISTER ',' indirect_IY {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xfd);
-            write_byte(0xae);
-            write_byte($4);
-          }
-        | MNEMO_CP REGISTER ',' REGISTER {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xb8 | $4);
-          }
-        | MNEMO_CP REGISTER ',' REGISTER_IX {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-              write_byte(0xdd);
-              write_byte(0xb8 | $4);
-          }
-        | MNEMO_CP REGISTER ',' REGISTER_IY {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xfd);
-            write_byte(0xb8 | $4);
-          }
-        | MNEMO_CP REGISTER ',' value_8bits {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xfe);
-            write_byte($4);
-          }
-        | MNEMO_CP REGISTER ',' REGISTER_IND_HL {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xbe);
-          }
-        | MNEMO_CP REGISTER ',' indirect_IX {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdd);
-            write_byte(0xbe);
-            write_byte($4);
-          }
-        | MNEMO_CP REGISTER ',' indirect_IY {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xfd);
-            write_byte(0xbe);
-            write_byte($4);
-          }
-        | MNEMO_ADD REGISTER {
-            if (zilog)
-              warning_message(5);
-            write_byte(0x80 | $2);
-          }
-        | MNEMO_ADD REGISTER_IX {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdd);
-            write_byte(0x80 | $2);
-          }
-        | MNEMO_ADD REGISTER_IY {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xfd);
-            write_byte(0x80 | $2);
-          }
-        | MNEMO_ADD value_8bits {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xc6);
-            write_byte($2);
-          }
-        | MNEMO_ADD REGISTER_IND_HL {
-            if (zilog)
-              warning_message(5);
-            write_byte(0x86);
-          }
-        | MNEMO_ADD indirect_IX {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdd);
-            write_byte(0x86);
-            write_byte($2);
-          }
-        | MNEMO_ADD indirect_IY {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xfd);
-            write_byte(0x86);
-            write_byte($2);
-          }
-        | MNEMO_ADC REGISTER {
-            if (zilog)
-              warning_message(5);
-            write_byte(0x88 | $2);
-          }
-        | MNEMO_ADC REGISTER_IX {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdd);
-            write_byte(0x88 | $2);
-          }
-        | MNEMO_ADC REGISTER_IY {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xfd);
-            write_byte(0x88|$2);
-          }
-        | MNEMO_ADC value_8bits {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xce);
-            write_byte($2);
-          }
-        | MNEMO_ADC REGISTER_IND_HL {
-            if (zilog)
-              warning_message(5);
-            write_byte(0x8e);
-          }
-        | MNEMO_ADC indirect_IX {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdd);
-            write_byte(0x8e);
-            write_byte($2);
-          }
-        | MNEMO_ADC indirect_IY {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xfd);
-            write_byte(0x8e);
-            write_byte($2);
-          }
-        | MNEMO_SUB REGISTER {
-            write_byte(0x90 | $2);
-          }
-        | MNEMO_SUB REGISTER_IX {
-            write_byte(0xdd);
-            write_byte(0x90 | $2);
-          }
-        | MNEMO_SUB REGISTER_IY {
-            write_byte(0xfd);
-            write_byte(0x90 | $2);
-          }
-        | MNEMO_SUB value_8bits {
-            write_byte(0xd6);
-            write_byte($2);
-          }
-        | MNEMO_SUB REGISTER_IND_HL {
-            write_byte(0x96);
-          }
-        | MNEMO_SUB indirect_IX {
-            write_byte(0xdd);
-            write_byte(0x96);
-            write_byte($2);
-          }
-        | MNEMO_SUB indirect_IY {
-            write_byte(0xfd);
-            write_byte(0x96);
-            write_byte($2);
-          }
-        | MNEMO_SBC REGISTER {
-            if (zilog)
-              warning_message(5);
-            write_byte(0x98 | $2);
-          }
-        | MNEMO_SBC REGISTER_IX {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdd);
-            write_byte(0x98 | $2);
-          }
-        | MNEMO_SBC REGISTER_IY {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xfd);
-            write_byte(0x98 | $2);
-          }
-        | MNEMO_SBC value_8bits {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xde);
-            write_byte($2);
-          }
-        | MNEMO_SBC REGISTER_IND_HL {
-            if (zilog)
-              warning_message(5);
-            write_byte(0x9e);
-          }
-        | MNEMO_SBC indirect_IX {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdd);
-            write_byte(0x9e);
-            write_byte($2);
-          }
-        | MNEMO_SBC indirect_IY {
-            if (zilog)
-              warning_message(5);
-              write_byte(0xfd);
-              write_byte(0x9e);
-              write_byte($2);
-          }
-        | MNEMO_AND REGISTER {
-            write_byte(0xa0 | $2);
-          }
-        | MNEMO_AND REGISTER_IX {
-            write_byte(0xdd);
-            write_byte(0xa0 | $2);
-          }
-        | MNEMO_AND REGISTER_IY {
-            write_byte(0xfd);
-            write_byte(0xa0 | $2);
-          }
-        | MNEMO_AND value_8bits {
-            write_byte(0xe6);
-            write_byte($2);
-          }
-        | MNEMO_AND REGISTER_IND_HL {
-            write_byte(0xa6);
-          }
-        | MNEMO_AND indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xa6);
-            write_byte($2);
-          }
-        | MNEMO_AND indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xa6);
-            write_byte($2);
-          }
-        | MNEMO_OR REGISTER {
-            write_byte(0xb0 | $2);
-          }
-        | MNEMO_OR REGISTER_IX {
-            write_byte(0xdd);
-            write_byte(0xb0 | $2);
-          }
-        | MNEMO_OR REGISTER_IY {
-            write_byte(0xfd);
-            write_byte(0xb0 | $2);
-          }
-        | MNEMO_OR value_8bits {
-            write_byte(0xf6);
-            write_byte($2);
-          }
-        | MNEMO_OR REGISTER_IND_HL {
-            write_byte(0xb6);
-          }
-        | MNEMO_OR indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xb6);
-            write_byte($2);
-          }
-        | MNEMO_OR indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xb6);
-            write_byte($2);
-          }
-        | MNEMO_XOR REGISTER {
-            write_byte(0xa8 | $2);
-          }
-        | MNEMO_XOR REGISTER_IX {
-            write_byte(0xdd);
-            write_byte(0xa8 | $2);
-          }
-        | MNEMO_XOR REGISTER_IY {
-            write_byte(0xfd);
-            write_byte(0xa8 | $2);
-          }
-        | MNEMO_XOR value_8bits {
-            write_byte(0xee);
-            write_byte($2);
-          }
-        | MNEMO_XOR REGISTER_IND_HL {
-            write_byte(0xae);
-          }
-        | MNEMO_XOR indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xae);
-            write_byte($2);
-          }
-        | MNEMO_XOR indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xae);
-            write_byte($2);
-          }
-        | MNEMO_CP REGISTER {
-            write_byte(0xb8 | $2);
-          }
-        | MNEMO_CP REGISTER_IX {
-            write_byte(0xdd);
-            write_byte(0xb8 | $2);
-          }
-        | MNEMO_CP REGISTER_IY {
-            write_byte(0xfd);
-            write_byte(0xb8 | $2);
-          }
-        | MNEMO_CP value_8bits {
-            write_byte(0xfe);
-            write_byte($2);
-          }
-        | MNEMO_CP REGISTER_IND_HL {
-            write_byte(0xbe);
-          }
-        | MNEMO_CP indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xbe);
-            write_byte($2);
-          }
-        | MNEMO_CP indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xbe);
-            write_byte($2);
-          }
-        | MNEMO_INC REGISTER {
-            write_byte(0x04 | ($2 << 3));
-          }
-        | MNEMO_INC REGISTER_IX {
-            write_byte(0xdd);
-            write_byte(0x04 | ($2 << 3));
-          }
-        | MNEMO_INC REGISTER_IY {
-            write_byte(0xfd);
-            write_byte(0x04 | ($2 << 3));
-          }
-        | MNEMO_INC REGISTER_IND_HL {
-            write_byte(0x34);
-          }
-        | MNEMO_INC indirect_IX {
-            write_byte(0xdd);
-            write_byte(0x34);
-            write_byte($2);
-          }
-        | MNEMO_INC indirect_IY {
-            write_byte(0xfd);
-            write_byte(0x34);
-            write_byte($2);
-          }
-        | MNEMO_DEC REGISTER {
-            write_byte(0x05 | ($2 << 3));
-          }
-        | MNEMO_DEC REGISTER_IX {
-            write_byte(0xdd);
-            write_byte(0x05 | ($2 << 3));
-          }
-        | MNEMO_DEC REGISTER_IY {
-            write_byte(0xfd);
-            write_byte(0x05 | ($2 << 3));
-          }
-        | MNEMO_DEC REGISTER_IND_HL {
-            write_byte(0x35);
-          }
-        | MNEMO_DEC indirect_IX {
-            write_byte(0xdd);
-            write_byte(0x35);
-            write_byte($2);
-          }
-        | MNEMO_DEC indirect_IY {
-            write_byte(0xfd);
-            write_byte(0x35);
-            write_byte($2);
-          }
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0x80|$4);
+    }
+  | MNEMO_ADD REGISTER ',' REGISTER_IX {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xdd);
+      write_byte(0x80 | $4);
+    }
+  | MNEMO_ADD REGISTER ',' REGISTER_IY {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xfd);
+      write_byte(0x80 | $4);
+    }
+  | MNEMO_ADD REGISTER ',' value_8bits {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xc6);
+      write_byte($4);
+    }
+  | MNEMO_ADD REGISTER ',' REGISTER_IND_HL {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0x86);
+    }
+  | MNEMO_ADD REGISTER ',' indirect_IX {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xdd);
+      write_byte(0x86);
+      write_byte($4);
+    }
+  | MNEMO_ADD REGISTER ',' indirect_IY {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xfd);
+      write_byte(0x86);
+      write_byte($4);
+    }
+  | MNEMO_ADC REGISTER ',' REGISTER {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0x88 | $4);
+    }
+  | MNEMO_ADC REGISTER ',' REGISTER_IX {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xdd);
+      write_byte(0x88 | $4);
+    }
+  | MNEMO_ADC REGISTER ',' REGISTER_IY {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xfd);
+      write_byte(0x88 | $4);
+    }
+  | MNEMO_ADC REGISTER ',' value_8bits {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xce);
+      write_byte($4);
+    }
+  | MNEMO_ADC REGISTER ',' REGISTER_IND_HL {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0x8e);
+    }
+  | MNEMO_ADC REGISTER ',' indirect_IX {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xdd);
+      write_byte(0x8e);
+      write_byte($4);
+    }
+  | MNEMO_ADC REGISTER ',' indirect_IY {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xfd);
+      write_byte(0x8e);
+      write_byte($4);
+    }
+  | MNEMO_SUB REGISTER ',' REGISTER {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0x90 | $4);
+    }
+  | MNEMO_SUB REGISTER ',' REGISTER_IX {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdd);
+      write_byte(0x90 | $4);
+    }
+  | MNEMO_SUB REGISTER ',' REGISTER_IY {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xfd);
+      write_byte(0x90 | $4);
+    }
+  | MNEMO_SUB REGISTER ',' value_8bits {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xd6);
+      write_byte($4);
+    }
+  | MNEMO_SUB REGISTER ',' REGISTER_IND_HL {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0x96);
+    }
+  | MNEMO_SUB REGISTER ',' indirect_IX {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdd);
+      write_byte(0x96);
+      write_byte($4);
+    }
+  | MNEMO_SUB REGISTER ',' indirect_IY {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xfd);
+      write_byte(0x96);
+      write_byte($4);
+    }
+  | MNEMO_SBC REGISTER ',' REGISTER {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0x98 | $4);
+    }
+  | MNEMO_SBC REGISTER ',' REGISTER_IX {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xdd);
+      write_byte(0x98 | $4);
+    }
+  | MNEMO_SBC REGISTER ',' REGISTER_IY {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xfd);
+      write_byte(0x98 | $4);
+    }
+  | MNEMO_SBC REGISTER ',' value_8bits {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xde);
+      write_byte($4);
+    }
+  | MNEMO_SBC REGISTER ',' REGISTER_IND_HL {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0x9e);
+    }
+  | MNEMO_SBC REGISTER ',' indirect_IX {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xdd);
+      write_byte(0x9e);
+      write_byte($4);
+    }
+  | MNEMO_SBC REGISTER ',' indirect_IY {
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xfd);
+      write_byte(0x9e);
+      write_byte($4);
+    }
+  | MNEMO_AND REGISTER ',' REGISTER {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xa0 | $4);
+    }
+  | MNEMO_AND REGISTER ',' REGISTER_IX {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdd);
+      write_byte(0xa0 | $4);
+    }
+  | MNEMO_AND REGISTER ',' REGISTER_IY {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xfd);
+      write_byte(0xa0 | $4);
+    }
+  | MNEMO_AND REGISTER ',' value_8bits {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xe6);
+      write_byte($4);
+    }
+  | MNEMO_AND REGISTER ',' REGISTER_IND_HL {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xa6);
+    }
+  | MNEMO_AND REGISTER ',' indirect_IX {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdd);
+      write_byte(0xa6);
+      write_byte($4);
+    }
+  | MNEMO_AND REGISTER ',' indirect_IY {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xfd);
+      write_byte(0xa6);
+      write_byte($4);
+    }
+  | MNEMO_OR REGISTER ',' REGISTER {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xb0 | $4);
+    }
+  | MNEMO_OR REGISTER ',' REGISTER_IX {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog) 
+        warning_message(5);
+      write_byte(0xdd);
+      write_byte(0xb0 | $4);
+    }
+  | MNEMO_OR REGISTER ',' REGISTER_IY {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xfd);
+      write_byte(0xb0 | $4);
+    }
+  | MNEMO_OR REGISTER ',' value_8bits {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xf6);
+      write_byte($4);
+    }
+  | MNEMO_OR REGISTER ',' REGISTER_IND_HL {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xb6);
+    }
+  | MNEMO_OR REGISTER ',' indirect_IX {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdd);
+      write_byte(0xb6);
+      write_byte($4);
+    }
+  | MNEMO_OR REGISTER ',' indirect_IY {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xfd);
+      write_byte(0xb6);
+      write_byte($4);
+    }
+  | MNEMO_XOR REGISTER ',' REGISTER {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xa8 | $4);
+    }
+  | MNEMO_XOR REGISTER ',' REGISTER_IX {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdd);
+      write_byte(0xa8 | $4);
+    }
+  | MNEMO_XOR REGISTER ',' REGISTER_IY {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xfd);
+      write_byte(0xa8 | $4);
+    }
+  | MNEMO_XOR REGISTER ',' value_8bits {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xee);
+      write_byte($4);
+    }
+  | MNEMO_XOR REGISTER ',' REGISTER_IND_HL {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xae);
+    }
+  | MNEMO_XOR REGISTER ',' indirect_IX {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdd);
+      write_byte(0xae);
+      write_byte($4);
+    }
+  | MNEMO_XOR REGISTER ',' indirect_IY {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xfd);
+      write_byte(0xae);
+      write_byte($4);
+    }
+  | MNEMO_CP REGISTER ',' REGISTER {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xb8 | $4);
+    }
+  | MNEMO_CP REGISTER ',' REGISTER_IX {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+        write_byte(0xdd);
+        write_byte(0xb8 | $4);
+    }
+  | MNEMO_CP REGISTER ',' REGISTER_IY {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xfd);
+      write_byte(0xb8 | $4);
+    }
+  | MNEMO_CP REGISTER ',' value_8bits {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xfe);
+      write_byte($4);
+    }
+  | MNEMO_CP REGISTER ',' REGISTER_IND_HL {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xbe);
+    }
+  | MNEMO_CP REGISTER ',' indirect_IX {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdd);
+      write_byte(0xbe);
+      write_byte($4);
+    }
+  | MNEMO_CP REGISTER ',' indirect_IY {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xfd);
+      write_byte(0xbe);
+      write_byte($4);
+    }
+  | MNEMO_ADD REGISTER {
+      if (zilog)
+        warning_message(5);
+      write_byte(0x80 | $2);
+    }
+  | MNEMO_ADD REGISTER_IX {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdd);
+      write_byte(0x80 | $2);
+    }
+  | MNEMO_ADD REGISTER_IY {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xfd);
+      write_byte(0x80 | $2);
+    }
+  | MNEMO_ADD value_8bits {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xc6);
+      write_byte($2);
+    }
+  | MNEMO_ADD REGISTER_IND_HL {
+      if (zilog)
+        warning_message(5);
+      write_byte(0x86);
+    }
+  | MNEMO_ADD indirect_IX {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdd);
+      write_byte(0x86);
+      write_byte($2);
+    }
+  | MNEMO_ADD indirect_IY {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xfd);
+      write_byte(0x86);
+      write_byte($2);
+    }
+  | MNEMO_ADC REGISTER {
+      if (zilog)
+        warning_message(5);
+      write_byte(0x88 | $2);
+    }
+  | MNEMO_ADC REGISTER_IX {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdd);
+      write_byte(0x88 | $2);
+    }
+  | MNEMO_ADC REGISTER_IY {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xfd);
+      write_byte(0x88|$2);
+    }
+  | MNEMO_ADC value_8bits {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xce);
+      write_byte($2);
+    }
+  | MNEMO_ADC REGISTER_IND_HL {
+      if (zilog)
+        warning_message(5);
+      write_byte(0x8e);
+    }
+  | MNEMO_ADC indirect_IX {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdd);
+      write_byte(0x8e);
+      write_byte($2);
+    }
+  | MNEMO_ADC indirect_IY {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xfd);
+      write_byte(0x8e);
+      write_byte($2);
+    }
+  | MNEMO_SUB REGISTER {
+      write_byte(0x90 | $2);
+    }
+  | MNEMO_SUB REGISTER_IX {
+      write_byte(0xdd);
+      write_byte(0x90 | $2);
+    }
+  | MNEMO_SUB REGISTER_IY {
+      write_byte(0xfd);
+      write_byte(0x90 | $2);
+    }
+  | MNEMO_SUB value_8bits {
+      write_byte(0xd6);
+      write_byte($2);
+    }
+  | MNEMO_SUB REGISTER_IND_HL {
+      write_byte(0x96);
+    }
+  | MNEMO_SUB indirect_IX {
+      write_byte(0xdd);
+      write_byte(0x96);
+      write_byte($2);
+    }
+  | MNEMO_SUB indirect_IY {
+      write_byte(0xfd);
+      write_byte(0x96);
+      write_byte($2);
+    }
+  | MNEMO_SBC REGISTER {
+      if (zilog)
+        warning_message(5);
+      write_byte(0x98 | $2);
+    }
+  | MNEMO_SBC REGISTER_IX {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdd);
+      write_byte(0x98 | $2);
+    }
+  | MNEMO_SBC REGISTER_IY {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xfd);
+      write_byte(0x98 | $2);
+    }
+  | MNEMO_SBC value_8bits {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xde);
+      write_byte($2);
+    }
+  | MNEMO_SBC REGISTER_IND_HL {
+      if (zilog)
+        warning_message(5);
+      write_byte(0x9e);
+    }
+  | MNEMO_SBC indirect_IX {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdd);
+      write_byte(0x9e);
+      write_byte($2);
+    }
+  | MNEMO_SBC indirect_IY {
+      if (zilog)
+        warning_message(5);
+        write_byte(0xfd);
+        write_byte(0x9e);
+        write_byte($2);
+    }
+  | MNEMO_AND REGISTER {
+      write_byte(0xa0 | $2);
+    }
+  | MNEMO_AND REGISTER_IX {
+      write_byte(0xdd);
+      write_byte(0xa0 | $2);
+    }
+  | MNEMO_AND REGISTER_IY {
+      write_byte(0xfd);
+      write_byte(0xa0 | $2);
+    }
+  | MNEMO_AND value_8bits {
+      write_byte(0xe6);
+      write_byte($2);
+    }
+  | MNEMO_AND REGISTER_IND_HL {
+      write_byte(0xa6);
+    }
+  | MNEMO_AND indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xa6);
+      write_byte($2);
+    }
+  | MNEMO_AND indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xa6);
+      write_byte($2);
+    }
+  | MNEMO_OR REGISTER {
+      write_byte(0xb0 | $2);
+    }
+  | MNEMO_OR REGISTER_IX {
+      write_byte(0xdd);
+      write_byte(0xb0 | $2);
+    }
+  | MNEMO_OR REGISTER_IY {
+      write_byte(0xfd);
+      write_byte(0xb0 | $2);
+    }
+  | MNEMO_OR value_8bits {
+      write_byte(0xf6);
+      write_byte($2);
+    }
+  | MNEMO_OR REGISTER_IND_HL {
+      write_byte(0xb6);
+    }
+  | MNEMO_OR indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xb6);
+      write_byte($2);
+    }
+  | MNEMO_OR indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xb6);
+      write_byte($2);
+    }
+  | MNEMO_XOR REGISTER {
+      write_byte(0xa8 | $2);
+    }
+  | MNEMO_XOR REGISTER_IX {
+      write_byte(0xdd);
+      write_byte(0xa8 | $2);
+    }
+  | MNEMO_XOR REGISTER_IY {
+      write_byte(0xfd);
+      write_byte(0xa8 | $2);
+    }
+  | MNEMO_XOR value_8bits {
+      write_byte(0xee);
+      write_byte($2);
+    }
+  | MNEMO_XOR REGISTER_IND_HL {
+      write_byte(0xae);
+    }
+  | MNEMO_XOR indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xae);
+      write_byte($2);
+    }
+  | MNEMO_XOR indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xae);
+      write_byte($2);
+    }
+  | MNEMO_CP REGISTER {
+      write_byte(0xb8 | $2);
+    }
+  | MNEMO_CP REGISTER_IX {
+      write_byte(0xdd);
+      write_byte(0xb8 | $2);
+    }
+  | MNEMO_CP REGISTER_IY {
+      write_byte(0xfd);
+      write_byte(0xb8 | $2);
+    }
+  | MNEMO_CP value_8bits {
+      write_byte(0xfe);
+      write_byte($2);
+    }
+  | MNEMO_CP REGISTER_IND_HL {
+      write_byte(0xbe);
+    }
+  | MNEMO_CP indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xbe);
+      write_byte($2);
+    }
+  | MNEMO_CP indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xbe);
+      write_byte($2);
+    }
+  | MNEMO_INC REGISTER {
+      write_byte(0x04 | ($2 << 3));
+    }
+  | MNEMO_INC REGISTER_IX {
+      write_byte(0xdd);
+      write_byte(0x04 | ($2 << 3));
+    }
+  | MNEMO_INC REGISTER_IY {
+      write_byte(0xfd);
+      write_byte(0x04 | ($2 << 3));
+    }
+  | MNEMO_INC REGISTER_IND_HL {
+      write_byte(0x34);
+    }
+  | MNEMO_INC indirect_IX {
+      write_byte(0xdd);
+      write_byte(0x34);
+      write_byte($2);
+    }
+  | MNEMO_INC indirect_IY {
+      write_byte(0xfd);
+      write_byte(0x34);
+      write_byte($2);
+    }
+  | MNEMO_DEC REGISTER {
+      write_byte(0x05 | ($2 << 3));
+    }
+  | MNEMO_DEC REGISTER_IX {
+      write_byte(0xdd);
+      write_byte(0x05 | ($2 << 3));
+    }
+  | MNEMO_DEC REGISTER_IY {
+      write_byte(0xfd);
+      write_byte(0x05 | ($2 << 3));
+    }
+  | MNEMO_DEC REGISTER_IND_HL {
+      write_byte(0x35);
+    }
+  | MNEMO_DEC indirect_IX {
+      write_byte(0xdd);
+      write_byte(0x35);
+      write_byte($2);
+    }
+  | MNEMO_DEC indirect_IY {
+      write_byte(0xfd);
+      write_byte(0x35);
+      write_byte($2);
+    }
 ;
 
 mnemo_math16bit: MNEMO_ADD REGISTER_PAIR ',' REGISTER_PAIR {
-            if ($2 != 2)
-              error_message(2);
-            write_byte(0x09 | ($4 << 4));
-          }
-        | MNEMO_ADC REGISTER_PAIR ',' REGISTER_PAIR {
-            if ($2 != 2)
-              error_message(2);
-            write_byte(0xed);
-            write_byte(0x4a | ($4 << 4));
-          }
-        | MNEMO_SBC REGISTER_PAIR ',' REGISTER_PAIR {
-            if ($2 != 2)
-              error_message(2);
-            write_byte(0xed);
-            write_byte(0x42 | ($4 << 4));
-          }
-        | MNEMO_ADD REGISTER_16_IX ',' REGISTER_PAIR {
-            if ($4 == 2)
-              error_message(2);
-            write_byte(0xdd);
-            write_byte(0x09 | ($4 << 4));
-          }
-        | MNEMO_ADD REGISTER_16_IX ',' REGISTER_16_IX {
-            write_byte(0xdd);
-            write_byte(0x29);
-          }
-        | MNEMO_ADD REGISTER_16_IY ',' REGISTER_PAIR {
-            if ($4 == 2)
-              error_message(2);
-            write_byte(0xfd);
-            write_byte(0x09 | ($4 << 4));
-          }
-        | MNEMO_ADD REGISTER_16_IY ',' REGISTER_16_IY {
-            write_byte(0xfd);
-            write_byte(0x29);
-          }
-        | MNEMO_INC REGISTER_PAIR {
-            write_byte(0x03 | ($2 << 4));
-          }
-        | MNEMO_INC REGISTER_16_IX {
-            write_byte(0xdd);
-            write_byte(0x23);
-          }
-        | MNEMO_INC REGISTER_16_IY {
-            write_byte(0xfd);
-            write_byte(0x23);
-          }
-        | MNEMO_DEC REGISTER_PAIR {
-            write_byte(0x0b | ($2 << 4));
-          }
-        | MNEMO_DEC REGISTER_16_IX {
-            write_byte(0xdd);
-            write_byte(0x2b);
-          }
-        | MNEMO_DEC REGISTER_16_IY {
-            write_byte(0xfd);
-            write_byte(0x2b);
-          }
+      if ($2 != 2)
+        error_message(2);
+      write_byte(0x09 | ($4 << 4));
+    }
+  | MNEMO_ADC REGISTER_PAIR ',' REGISTER_PAIR {
+      if ($2 != 2)
+        error_message(2);
+      write_byte(0xed);
+      write_byte(0x4a | ($4 << 4));
+    }
+  | MNEMO_SBC REGISTER_PAIR ',' REGISTER_PAIR {
+      if ($2 != 2)
+        error_message(2);
+      write_byte(0xed);
+      write_byte(0x42 | ($4 << 4));
+    }
+  | MNEMO_ADD REGISTER_16_IX ',' REGISTER_PAIR {
+      if ($4 == 2)
+        error_message(2);
+      write_byte(0xdd);
+      write_byte(0x09 | ($4 << 4));
+    }
+  | MNEMO_ADD REGISTER_16_IX ',' REGISTER_16_IX {
+      write_byte(0xdd);
+      write_byte(0x29);
+    }
+  | MNEMO_ADD REGISTER_16_IY ',' REGISTER_PAIR {
+      if ($4 == 2)
+        error_message(2);
+      write_byte(0xfd);
+      write_byte(0x09 | ($4 << 4));
+    }
+  | MNEMO_ADD REGISTER_16_IY ',' REGISTER_16_IY {
+      write_byte(0xfd);
+      write_byte(0x29);
+    }
+  | MNEMO_INC REGISTER_PAIR {
+      write_byte(0x03 | ($2 << 4));
+    }
+  | MNEMO_INC REGISTER_16_IX {
+      write_byte(0xdd);
+      write_byte(0x23);
+    }
+  | MNEMO_INC REGISTER_16_IY {
+      write_byte(0xfd);
+      write_byte(0x23);
+    }
+  | MNEMO_DEC REGISTER_PAIR {
+      write_byte(0x0b | ($2 << 4));
+    }
+  | MNEMO_DEC REGISTER_16_IX {
+      write_byte(0xdd);
+      write_byte(0x2b);
+    }
+  | MNEMO_DEC REGISTER_16_IY {
+      write_byte(0xfd);
+      write_byte(0x2b);
+    }
 ;
 
 mnemo_general: MNEMO_DAA {
-            write_byte(0x27);
-          }
-        | MNEMO_CPL {
-            write_byte(0x2f);
-          }
-        | MNEMO_NEG {
-            write_byte(0xed);
-            write_byte(0x44);
-          }
-        | MNEMO_CCF {
-            write_byte(0x3f);
-          }
-        | MNEMO_SCF {
-            write_byte(0x37);
-          }
-        | MNEMO_NOP {
-            write_byte(0x00);
-          }
-        | MNEMO_HALT {
-            write_byte(0x76);
-          }
-        | MNEMO_DI {
-            write_byte(0xf3);
-          }
-        | MNEMO_EI {
-            write_byte(0xfb);
-          }
-        | MNEMO_IM value_8bits {
-            if (($2 < 0) || ($2 > 2))
-              error_message(3);
-            write_byte(0xed);
-            if ($2 == 0)
-              write_byte(0x46);
-            else if ($2 == 1)
-              write_byte(0x56);
-            else
-              write_byte(0x5e);
-          }
+      write_byte(0x27);
+    }
+  | MNEMO_CPL {
+      write_byte(0x2f);
+    }
+  | MNEMO_NEG {
+      write_byte(0xed);
+      write_byte(0x44);
+    }
+  | MNEMO_CCF {
+      write_byte(0x3f);
+    }
+  | MNEMO_SCF {
+      write_byte(0x37);
+    }
+  | MNEMO_NOP {
+      write_byte(0x00);
+    }
+  | MNEMO_HALT {
+      write_byte(0x76);
+    }
+  | MNEMO_DI {
+      write_byte(0xf3);
+    }
+  | MNEMO_EI {
+      write_byte(0xfb);
+    }
+  | MNEMO_IM value_8bits {
+      if (($2 < 0) || ($2 > 2))
+        error_message(3);
+      write_byte(0xed);
+      if ($2 == 0)
+        write_byte(0x46);
+      else if ($2 == 1)
+        write_byte(0x56);
+      else
+        write_byte(0x5e);
+    }
 ;
 
 mnemo_rotate: MNEMO_RLCA {
-            write_byte(0x07);
-          }
-        | MNEMO_RLA {
-            write_byte(0x17);
-          }
-        | MNEMO_RRCA {
-            write_byte(0x0f);
-          }
-        | MNEMO_RRA {
-            write_byte(0x1f);
-          }
-        | MNEMO_RLC REGISTER {
-            write_byte(0xcb);
-            write_byte($2);
-          }
-        | MNEMO_RLC REGISTER_IND_HL {
-            write_byte(0xcb);
-            write_byte(0x06);
-          }
-        | MNEMO_RLC indirect_IX ',' REGISTER {
-            if ($4 == 6)
-              error_message(2);
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte($4);
-          }
-        | MNEMO_RLC indirect_IY ',' REGISTER {
-            if ($4 == 6)
-              error_message(2);
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte($4);
-          }
-        | MNEMO_RLC indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte(0x06);
-          }
-        | MNEMO_RLC indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte(0x06);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_RLC indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($5);
-            write_byte($2);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_RLC indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($5);
-            write_byte($2);
-          }
-        | MNEMO_RL REGISTER {
-            write_byte(0xcb);
-            write_byte(0x10 | $2);
-          }
-        | MNEMO_RL REGISTER_IND_HL {
-            write_byte(0xcb);
-            write_byte(0x16);
-          }
-        | MNEMO_RL indirect_IX ',' REGISTER {
-            if ($4 == 6)
-              error_message(2);
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte($4 | 0x10);
-          }
-        | MNEMO_RL indirect_IY ',' REGISTER {
-            if ($4 == 6)
-              error_message(2);
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte($4 | 0x10);
-          }
-        | MNEMO_RL indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte(0x16);
-          }
-        | MNEMO_RL indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte(0x16);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_RL indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($5);
-            write_byte(0x10 | $2);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_RL indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($5);
-            write_byte(0x10 | $2);
-          }
-        | MNEMO_RRC REGISTER {
-            write_byte(0xcb);
-            write_byte(0x08 | $2);
-          }
-        | MNEMO_RRC REGISTER_IND_HL {
-            write_byte(0xcb);
-            write_byte(0x0e);
-          }
-        | MNEMO_RRC indirect_IX ',' REGISTER {
-            if ($4 == 6)
-              error_message(2);
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte($4 | 0x08);
-          }
-        | MNEMO_RRC indirect_IY ',' REGISTER {
-            if ($4 == 6)
-              error_message(2);
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte($4 | 0x08);
-          }
-        | MNEMO_RRC indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte(0x0e);
-          }
-        | MNEMO_RRC indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte(0x0e);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_RRC indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($5);
-            write_byte(0x08 | $2);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_RRC indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($5);
-            write_byte(0x08 | $2);
-          }
-        | MNEMO_RR REGISTER {
-            write_byte(0xcb);
-            write_byte(0x18 | $2);
-          }
-        | MNEMO_RR REGISTER_IND_HL {
-            write_byte(0xcb);
-            write_byte(0x1e);
-          }
-        | MNEMO_RR indirect_IX ',' REGISTER {
-            if ($4 == 6)
-              error_message(2);
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte($4 | 0x18);
-          }
-        | MNEMO_RR indirect_IY ',' REGISTER {
-            if ($4 == 6)
-              error_message(2);
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte($4 | 0x18);
-          }
-        | MNEMO_RR indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte(0x1e);
-          }
-        | MNEMO_RR indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte(0x1e);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_RR indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($5);
-            write_byte(0x18 | $2);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_RR indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($5);
-            write_byte(0x18 | $2);
-          }
-        | MNEMO_SLA REGISTER {
-            write_byte(0xcb);
-            write_byte(0x20 | $2);
-          }
-        | MNEMO_SLA REGISTER_IND_HL {
-            write_byte(0xcb);
-            write_byte(0x26);
-          } 
-        | MNEMO_SLA indirect_IX ',' REGISTER {
-            if ($4 == 6)
-              error_message(2);
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte($4 | 0x20);
-          }
-        | MNEMO_SLA indirect_IY ',' REGISTER {
-            if ($4 == 6)
-              error_message(2);
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte($4 | 0x20);
-          }
-        | MNEMO_SLA indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte(0x26);
-          }
-        | MNEMO_SLA indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte(0x26);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_SLA indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($5);
-            write_byte(0x20 | $2);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_SLA indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($5);
-            write_byte(0x20 | $2);
-          }
-        | MNEMO_SLL REGISTER {
-            write_byte(0xcb);
-            write_byte(0x30 | $2);
-          }
-        | MNEMO_SLL REGISTER_IND_HL {
-            write_byte(0xcb);
-            write_byte(0x36);
-          }
-        | MNEMO_SLL indirect_IX ',' REGISTER {
-            if ($4 == 6)
-              error_message(2);
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte($4 | 0x30);
-          }
-        | MNEMO_SLL indirect_IY ',' REGISTER {
-            if ($4 == 6)
-              error_message(2);
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte($4 | 0x30);
-          }
-        | MNEMO_SLL indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte(0x36);
-          }
-        | MNEMO_SLL indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte(0x36);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_SLL indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($5);
-            write_byte(0x30 | $2);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_SLL indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($5);
-            write_byte(0x30 | $2);
-          }
-        | MNEMO_SRA REGISTER {
-            write_byte(0xcb);
-            write_byte(0x28 | $2);
-          }
-        | MNEMO_SRA REGISTER_IND_HL {
-            write_byte(0xcb);
-            write_byte(0x2e);
-          }
-        | MNEMO_SRA indirect_IX ',' REGISTER {
-            if ($4 == 6)
-              error_message(2);
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte($4 | 0x28);
-          }
-        | MNEMO_SRA indirect_IY ',' REGISTER {
-            if ($4 == 6)
-              error_message(2);
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte($4 | 0x28);
-          }
-        | MNEMO_SRA indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte(0x2e);
-          }
-        | MNEMO_SRA indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte(0x2e);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_SRA indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($5);
-            write_byte(0x28 | $2);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_SRA indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($5);
-            write_byte(0x28 | $2);
-          }
-        | MNEMO_SRL REGISTER {
-            write_byte(0xcb);
-            write_byte(0x38 | $2);
-          }
-        | MNEMO_SRL REGISTER_IND_HL {
-            write_byte(0xcb);
-            write_byte(0x3e);
-          }
-        | MNEMO_SRL indirect_IX ',' REGISTER {
-            if ($4 == 6)
-              error_message(2);
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte($4 | 0x38);
-          }
-        | MNEMO_SRL indirect_IY ',' REGISTER {
-            if ($4 == 6)
-              error_message(2);
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte($4 | 0x38);
-          }
-        | MNEMO_SRL indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte(0x3e);
-          }
-        | MNEMO_SRL indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($2);
-            write_byte(0x3e);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_SRL indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($5);
-            write_byte(0x38 | $2);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_SRL indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($5);
-            write_byte(0x38|$2);
-          }
-        | MNEMO_RLD {
-            write_byte(0xed);
-            write_byte(0x6f);
-          }
-        | MNEMO_RRD {
-            write_byte(0xed);
-            write_byte(0x67);
-          }
+      write_byte(0x07);
+    }
+  | MNEMO_RLA {
+      write_byte(0x17);
+    }
+  | MNEMO_RRCA {
+      write_byte(0x0f);
+    }
+  | MNEMO_RRA {
+      write_byte(0x1f);
+    }
+  | MNEMO_RLC REGISTER {
+      write_byte(0xcb);
+      write_byte($2);
+    }
+  | MNEMO_RLC REGISTER_IND_HL {
+      write_byte(0xcb);
+      write_byte(0x06);
+    }
+  | MNEMO_RLC indirect_IX ',' REGISTER {
+      if ($4 == 6)
+        error_message(2);
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte($4);
+    }
+  | MNEMO_RLC indirect_IY ',' REGISTER {
+      if ($4 == 6)
+        error_message(2);
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte($4);
+    }
+  | MNEMO_RLC indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte(0x06);
+    }
+  | MNEMO_RLC indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte(0x06);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_RLC indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($5);
+      write_byte($2);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_RLC indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($5);
+      write_byte($2);
+    }
+  | MNEMO_RL REGISTER {
+      write_byte(0xcb);
+      write_byte(0x10 | $2);
+    }
+  | MNEMO_RL REGISTER_IND_HL {
+      write_byte(0xcb);
+      write_byte(0x16);
+    }
+  | MNEMO_RL indirect_IX ',' REGISTER {
+      if ($4 == 6)
+        error_message(2);
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte($4 | 0x10);
+    }
+  | MNEMO_RL indirect_IY ',' REGISTER {
+      if ($4 == 6)
+        error_message(2);
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte($4 | 0x10);
+    }
+  | MNEMO_RL indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte(0x16);
+    }
+  | MNEMO_RL indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte(0x16);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_RL indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($5);
+      write_byte(0x10 | $2);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_RL indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($5);
+      write_byte(0x10 | $2);
+    }
+  | MNEMO_RRC REGISTER {
+      write_byte(0xcb);
+      write_byte(0x08 | $2);
+    }
+  | MNEMO_RRC REGISTER_IND_HL {
+      write_byte(0xcb);
+      write_byte(0x0e);
+    }
+  | MNEMO_RRC indirect_IX ',' REGISTER {
+      if ($4 == 6)
+        error_message(2);
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte($4 | 0x08);
+    }
+  | MNEMO_RRC indirect_IY ',' REGISTER {
+      if ($4 == 6)
+        error_message(2);
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte($4 | 0x08);
+    }
+  | MNEMO_RRC indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte(0x0e);
+    }
+  | MNEMO_RRC indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte(0x0e);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_RRC indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($5);
+      write_byte(0x08 | $2);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_RRC indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($5);
+      write_byte(0x08 | $2);
+    }
+  | MNEMO_RR REGISTER {
+      write_byte(0xcb);
+      write_byte(0x18 | $2);
+    }
+  | MNEMO_RR REGISTER_IND_HL {
+      write_byte(0xcb);
+      write_byte(0x1e);
+    }
+  | MNEMO_RR indirect_IX ',' REGISTER {
+      if ($4 == 6)
+        error_message(2);
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte($4 | 0x18);
+    }
+  | MNEMO_RR indirect_IY ',' REGISTER {
+      if ($4 == 6)
+        error_message(2);
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte($4 | 0x18);
+    }
+  | MNEMO_RR indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte(0x1e);
+    }
+  | MNEMO_RR indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte(0x1e);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_RR indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($5);
+      write_byte(0x18 | $2);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_RR indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($5);
+      write_byte(0x18 | $2);
+    }
+  | MNEMO_SLA REGISTER {
+      write_byte(0xcb);
+      write_byte(0x20 | $2);
+    }
+  | MNEMO_SLA REGISTER_IND_HL {
+      write_byte(0xcb);
+      write_byte(0x26);
+    } 
+  | MNEMO_SLA indirect_IX ',' REGISTER {
+      if ($4 == 6)
+        error_message(2);
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte($4 | 0x20);
+    }
+  | MNEMO_SLA indirect_IY ',' REGISTER {
+      if ($4 == 6)
+        error_message(2);
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte($4 | 0x20);
+    }
+  | MNEMO_SLA indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte(0x26);
+    }
+  | MNEMO_SLA indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte(0x26);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_SLA indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($5);
+      write_byte(0x20 | $2);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_SLA indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($5);
+      write_byte(0x20 | $2);
+    }
+  | MNEMO_SLL REGISTER {
+      write_byte(0xcb);
+      write_byte(0x30 | $2);
+    }
+  | MNEMO_SLL REGISTER_IND_HL {
+      write_byte(0xcb);
+      write_byte(0x36);
+    }
+  | MNEMO_SLL indirect_IX ',' REGISTER {
+      if ($4 == 6)
+        error_message(2);
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte($4 | 0x30);
+    }
+  | MNEMO_SLL indirect_IY ',' REGISTER {
+      if ($4 == 6)
+        error_message(2);
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte($4 | 0x30);
+    }
+  | MNEMO_SLL indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte(0x36);
+    }
+  | MNEMO_SLL indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte(0x36);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_SLL indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($5);
+      write_byte(0x30 | $2);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_SLL indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($5);
+      write_byte(0x30 | $2);
+    }
+  | MNEMO_SRA REGISTER {
+      write_byte(0xcb);
+      write_byte(0x28 | $2);
+    }
+  | MNEMO_SRA REGISTER_IND_HL {
+      write_byte(0xcb);
+      write_byte(0x2e);
+    }
+  | MNEMO_SRA indirect_IX ',' REGISTER {
+      if ($4 == 6)
+        error_message(2);
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte($4 | 0x28);
+    }
+  | MNEMO_SRA indirect_IY ',' REGISTER {
+      if ($4 == 6)
+        error_message(2);
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte($4 | 0x28);
+    }
+  | MNEMO_SRA indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte(0x2e);
+    }
+  | MNEMO_SRA indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte(0x2e);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_SRA indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($5);
+      write_byte(0x28 | $2);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_SRA indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($5);
+      write_byte(0x28 | $2);
+    }
+  | MNEMO_SRL REGISTER {
+      write_byte(0xcb);
+      write_byte(0x38 | $2);
+    }
+  | MNEMO_SRL REGISTER_IND_HL {
+      write_byte(0xcb);
+      write_byte(0x3e);
+    }
+  | MNEMO_SRL indirect_IX ',' REGISTER {
+      if ($4 == 6)
+        error_message(2);
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte($4 | 0x38);
+    }
+  | MNEMO_SRL indirect_IY ',' REGISTER {
+      if ($4 == 6)
+        error_message(2);
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte($4 | 0x38);
+    }
+  | MNEMO_SRL indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte(0x3e);
+    }
+  | MNEMO_SRL indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($2);
+      write_byte(0x3e);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_SRL indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($5);
+      write_byte(0x38 | $2);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_SRL indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($5);
+      write_byte(0x38|$2);
+    }
+  | MNEMO_RLD {
+      write_byte(0xed);
+      write_byte(0x6f);
+    }
+  | MNEMO_RRD {
+      write_byte(0xed);
+      write_byte(0x67);
+    }
 ;
 
 mnemo_bits: MNEMO_BIT value_3bits ',' REGISTER {
-            write_byte(0xcb);
-            write_byte(0x40 | ($2 << 3) | ($4));
-          }
-        | MNEMO_BIT value_3bits ',' REGISTER_IND_HL {
-            write_byte(0xcb);
-            write_byte(0x46 | ($2 << 3));
-          }
-        | MNEMO_BIT value_3bits ',' indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($4);
-            write_byte(0x46 | ($2 << 3));
-          }
-        | MNEMO_BIT value_3bits ',' indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($4);
-            write_byte(0x46 | ($2 << 3));
-          }
-        | MNEMO_SET value_3bits ',' REGISTER {
-            write_byte(0xcb);
-            write_byte(0xc0 | ($2 << 3) | ($4));
-          }
-        | MNEMO_SET value_3bits ',' REGISTER_IND_HL {
-            write_byte(0xcb);
-            write_byte(0xc6 | ($2 << 3));
-          }
-        | MNEMO_SET value_3bits ',' indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($4);
-            write_byte(0xc6 | ($2 << 3));
-          }
-        | MNEMO_SET value_3bits ',' indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($4);
-            write_byte(0xc6 | ($2 << 3));
-          }
-        | MNEMO_SET value_3bits ',' indirect_IX ',' REGISTER {
-            if ($6 == 6)
-              error_message(2);
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($4);
-            write_byte(0xc0 | ($2 << 3) | $6);
-          }
-        | MNEMO_SET value_3bits ',' indirect_IY ',' REGISTER {
-            if ($6 == 6)
-              error_message(2);
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($4);
-            write_byte(0xc0 | ($2 << 3) | $6);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_SET value_3bits ',' indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($7);
-            write_byte(0xc0 | ($5 << 3) | $2);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_SET value_3bits ',' indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($7);
-            write_byte(0xc0 | ($5 << 3) | $2);
-          }
-        | MNEMO_RES value_3bits ',' REGISTER {
-            write_byte(0xcb);
-            write_byte(0x80 | ($2 << 3) | ($4));
-          }
-        | MNEMO_RES value_3bits ',' REGISTER_IND_HL {
-            write_byte(0xcb);
-            write_byte(0x86 | ($2 << 3));
-          }
-        | MNEMO_RES value_3bits ',' indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($4);
-            write_byte(0x86 | ($2 << 3));
-          }
-        | MNEMO_RES value_3bits ',' indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($4);
-            write_byte(0x86 | ($2 << 3));
-          }
-        | MNEMO_RES value_3bits ',' indirect_IX ',' REGISTER {
-            if ($6 == 6)
-              error_message(2);
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($4);
-            write_byte(0x80 | ($2 << 3) | $6);
-          }
-        | MNEMO_RES value_3bits ',' indirect_IY ',' REGISTER {
-            if ($6 == 6)
-              error_message(2);
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($4);
-            write_byte(0x80 | ($2 << 3) | $6);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_RES value_3bits ',' indirect_IX {
-            write_byte(0xdd);
-            write_byte(0xcb);
-            write_byte($7);
-            write_byte(0x80 | ($5 << 3) | $2);
-          }
-        | MNEMO_LD REGISTER ',' MNEMO_RES value_3bits ',' indirect_IY {
-            write_byte(0xfd);
-            write_byte(0xcb);
-            write_byte($7);
-            write_byte(0x80 | ($5 << 3) | $2);
-          }
+      write_byte(0xcb);
+      write_byte(0x40 | ($2 << 3) | ($4));
+    }
+  | MNEMO_BIT value_3bits ',' REGISTER_IND_HL {
+      write_byte(0xcb);
+      write_byte(0x46 | ($2 << 3));
+    }
+  | MNEMO_BIT value_3bits ',' indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($4);
+      write_byte(0x46 | ($2 << 3));
+    }
+  | MNEMO_BIT value_3bits ',' indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($4);
+      write_byte(0x46 | ($2 << 3));
+    }
+  | MNEMO_SET value_3bits ',' REGISTER {
+      write_byte(0xcb);
+      write_byte(0xc0 | ($2 << 3) | ($4));
+    }
+  | MNEMO_SET value_3bits ',' REGISTER_IND_HL {
+      write_byte(0xcb);
+      write_byte(0xc6 | ($2 << 3));
+    }
+  | MNEMO_SET value_3bits ',' indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($4);
+      write_byte(0xc6 | ($2 << 3));
+    }
+  | MNEMO_SET value_3bits ',' indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($4);
+      write_byte(0xc6 | ($2 << 3));
+    }
+  | MNEMO_SET value_3bits ',' indirect_IX ',' REGISTER {
+      if ($6 == 6)
+        error_message(2);
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($4);
+      write_byte(0xc0 | ($2 << 3) | $6);
+    }
+  | MNEMO_SET value_3bits ',' indirect_IY ',' REGISTER {
+      if ($6 == 6)
+        error_message(2);
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($4);
+      write_byte(0xc0 | ($2 << 3) | $6);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_SET value_3bits ',' indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($7);
+      write_byte(0xc0 | ($5 << 3) | $2);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_SET value_3bits ',' indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($7);
+      write_byte(0xc0 | ($5 << 3) | $2);
+    }
+  | MNEMO_RES value_3bits ',' REGISTER {
+      write_byte(0xcb);
+      write_byte(0x80 | ($2 << 3) | ($4));
+    }
+  | MNEMO_RES value_3bits ',' REGISTER_IND_HL {
+      write_byte(0xcb);
+      write_byte(0x86 | ($2 << 3));
+    }
+  | MNEMO_RES value_3bits ',' indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($4);
+      write_byte(0x86 | ($2 << 3));
+    }
+  | MNEMO_RES value_3bits ',' indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($4);
+      write_byte(0x86 | ($2 << 3));
+    }
+  | MNEMO_RES value_3bits ',' indirect_IX ',' REGISTER {
+      if ($6 == 6)
+        error_message(2);
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($4);
+      write_byte(0x80 | ($2 << 3) | $6);
+    }
+  | MNEMO_RES value_3bits ',' indirect_IY ',' REGISTER {
+      if ($6 == 6)
+        error_message(2);
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($4);
+      write_byte(0x80 | ($2 << 3) | $6);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_RES value_3bits ',' indirect_IX {
+      write_byte(0xdd);
+      write_byte(0xcb);
+      write_byte($7);
+      write_byte(0x80 | ($5 << 3) | $2);
+    }
+  | MNEMO_LD REGISTER ',' MNEMO_RES value_3bits ',' indirect_IY {
+      write_byte(0xfd);
+      write_byte(0xcb);
+      write_byte($7);
+      write_byte(0x80 | ($5 << 3) | $2);
+    }
 ;
 
 mnemo_io: MNEMO_IN REGISTER ',' '[' value_8bits ']' {
-            if ($2 != 7)
-              error_message(4);
-            write_byte(0xdb);
-            write_byte($5);
-          }
-        | MNEMO_IN REGISTER ',' value_8bits {
-            if ($2 != 7)
-              error_message(4);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdb);
-            write_byte($4);
-          }
-        | MNEMO_IN REGISTER ',' '[' REGISTER ']' {
-            if ($5 != 1)
-              error_message(2);
-            write_byte(0xed);
-            write_byte(0x40 | ($2 << 3));
-          }
-        | MNEMO_IN '[' REGISTER ']'{
-            if ($3 != 1)
-              error_message(2);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xed);
-            write_byte(0x70);
-          }
-        | MNEMO_IN REGISTER_F ',' '[' REGISTER ']' {
-            if ($5 != 1)
-              error_message(2);
-            write_byte(0xed);
-            write_byte(0x70);
-          }
-        | MNEMO_INI {
-            write_byte(0xed);
-            write_byte(0xa2);
-          }
-        | MNEMO_INIR {
-            write_byte(0xed);
-            write_byte(0xb2);
-          }
-        | MNEMO_IND {
-            write_byte(0xed);
-            write_byte(0xaa);
-          }
-        | MNEMO_INDR {
-            write_byte(0xed);
-            write_byte(0xba);
-          }
-        | MNEMO_OUT '[' value_8bits ']' ',' REGISTER {
-            if ($6 != 7)
-              error_message(5);
-            write_byte(0xd3);
-            write_byte($3);
-          }
-        | MNEMO_OUT value_8bits ',' REGISTER {
-            if ($4 != 7)
-              error_message(5);
-            if (zilog)
-              warning_message(5);
-            write_byte(0xd3);
-            write_byte($2);
-          }
-        | MNEMO_OUT '[' REGISTER ']' ',' REGISTER {
-            if ($3 != 1)
-              error_message(2);
-            write_byte(0xed);
-            write_byte(0x41 | ($6 << 3));
-          }
-        | MNEMO_OUT '[' REGISTER ']' ',' value_8bits {
-            if ($3 != 1)
-              error_message(2);
-            if ($6 != 0)
-              error_message(6);
-            write_byte(0xed);
-            write_byte(0x71);
-          }
-        | MNEMO_OUTI {
-            write_byte(0xed);
-            write_byte(0xa3);
-          }
-        | MNEMO_OTIR {
-            write_byte(0xed);
-            write_byte(0xb3);
-          }
-        | MNEMO_OUTD {
-            write_byte(0xed);
-            write_byte(0xab);
-          }
-        | MNEMO_OTDR {
-            write_byte(0xed);
-            write_byte(0xbb);
-          }
-        | MNEMO_IN '[' value_8bits ']' {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdb);
-            write_byte($3);
-          }
-        | MNEMO_IN value_8bits {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xdb);
-            write_byte($2);
-          }
-        | MNEMO_OUT '[' value_8bits ']' {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xd3);
-            write_byte($3);
-          }
-        | MNEMO_OUT value_8bits {
-            if (zilog)
-              warning_message(5);
-            write_byte(0xd3);
-            write_byte($2);
-          }
+      if ($2 != 7)
+        error_message(4);
+      write_byte(0xdb);
+      write_byte($5);
+    }
+  | MNEMO_IN REGISTER ',' value_8bits {
+      if ($2 != 7)
+        error_message(4);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdb);
+      write_byte($4);
+    }
+  | MNEMO_IN REGISTER ',' '[' REGISTER ']' {
+      if ($5 != 1)
+        error_message(2);
+      write_byte(0xed);
+      write_byte(0x40 | ($2 << 3));
+    }
+  | MNEMO_IN '[' REGISTER ']'{
+      if ($3 != 1)
+        error_message(2);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xed);
+      write_byte(0x70);
+    }
+  | MNEMO_IN REGISTER_F ',' '[' REGISTER ']' {
+      if ($5 != 1)
+        error_message(2);
+      write_byte(0xed);
+      write_byte(0x70);
+    }
+  | MNEMO_INI {
+      write_byte(0xed);
+      write_byte(0xa2);
+    }
+  | MNEMO_INIR {
+      write_byte(0xed);
+      write_byte(0xb2);
+    }
+  | MNEMO_IND {
+      write_byte(0xed);
+      write_byte(0xaa);
+    }
+  | MNEMO_INDR {
+      write_byte(0xed);
+      write_byte(0xba);
+    }
+  | MNEMO_OUT '[' value_8bits ']' ',' REGISTER {
+      if ($6 != 7)
+        error_message(5);
+      write_byte(0xd3);
+      write_byte($3);
+    }
+  | MNEMO_OUT value_8bits ',' REGISTER {
+      if ($4 != 7)
+        error_message(5);
+      if (zilog)
+        warning_message(5);
+      write_byte(0xd3);
+      write_byte($2);
+    }
+  | MNEMO_OUT '[' REGISTER ']' ',' REGISTER {
+      if ($3 != 1)
+        error_message(2);
+      write_byte(0xed);
+      write_byte(0x41 | ($6 << 3));
+    }
+  | MNEMO_OUT '[' REGISTER ']' ',' value_8bits {
+      if ($3 != 1)
+        error_message(2);
+      if ($6 != 0)
+        error_message(6);
+      write_byte(0xed);
+      write_byte(0x71);
+    }
+  | MNEMO_OUTI {
+      write_byte(0xed);
+      write_byte(0xa3);
+    }
+  | MNEMO_OTIR {
+      write_byte(0xed);
+      write_byte(0xb3);
+    }
+  | MNEMO_OUTD {
+      write_byte(0xed);
+      write_byte(0xab);
+    }
+  | MNEMO_OTDR {
+      write_byte(0xed);
+      write_byte(0xbb);
+    }
+  | MNEMO_IN '[' value_8bits ']' {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdb);
+      write_byte($3);
+    }
+  | MNEMO_IN value_8bits {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xdb);
+      write_byte($2);
+    }
+  | MNEMO_OUT '[' value_8bits ']' {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xd3);
+      write_byte($3);
+    }
+  | MNEMO_OUT value_8bits {
+      if (zilog)
+        warning_message(5);
+      write_byte(0xd3);
+      write_byte($2);
+    }
 ;
 
 mnemo_jump: MNEMO_JP value_16bits {
-            write_byte(0xc3);
-            write_word($2);
-          }
-        | MNEMO_JP CONDITION ',' value_16bits {
-            write_byte(0xc2 | ($2 << 3));
-            write_word($4);
-          }
-        | MNEMO_JP REGISTER ',' value_16bits {
-            if ($2 != 1)
-              error_message(7);
-            write_byte(0xda);
-            write_word($4);
-          }
-        | MNEMO_JR value_16bits {
-            write_byte(0x18);
-            relative_jump($2);
-          }
-        | MNEMO_JR REGISTER ',' value_16bits {
-            if ($2 != 1)
-              error_message(7);
-            write_byte(0x38);
-            relative_jump($4);
-          }
-        | MNEMO_JR CONDITION ',' value_16bits {
-            if ($2 == 2)
-              write_byte(0x30);
-            else if ($2 == 1)
-              write_byte(0x28);
-            else if ($2 == 0)
-              write_byte(0x20);
-            else
-              error_message(9);
-            relative_jump($4);
-          }
-        | MNEMO_JP REGISTER_PAIR {
-            if ($2 != 2)
-              error_message(2);
-            write_byte(0xe9);
-          }
-        | MNEMO_JP REGISTER_IND_HL {
-            write_byte(0xe9);
-          }
-        | MNEMO_JP REGISTER_16_IX {
-            write_byte(0xdd);
-            write_byte(0xe9);
-          }
-        | MNEMO_JP REGISTER_16_IY {
-            write_byte(0xfd);
-            write_byte(0xe9);
-          }
-        | MNEMO_JP '[' REGISTER_16_IX ']' {
-            write_byte(0xdd);
-            write_byte(0xe9);
-          }
-        | MNEMO_JP '[' REGISTER_16_IY ']' {
-            write_byte(0xfd);
-            write_byte(0xe9);
-          }
-        | MNEMO_DJNZ value_16bits {
-            write_byte(0x10);
-            relative_jump($2);
-          }
+      write_byte(0xc3);
+      write_word($2);
+    }
+  | MNEMO_JP CONDITION ',' value_16bits {
+      write_byte(0xc2 | ($2 << 3));
+      write_word($4);
+    }
+  | MNEMO_JP REGISTER ',' value_16bits {
+      if ($2 != 1)
+        error_message(7);
+      write_byte(0xda);
+      write_word($4);
+    }
+  | MNEMO_JR value_16bits {
+      write_byte(0x18);
+      relative_jump($2);
+    }
+  | MNEMO_JR REGISTER ',' value_16bits {
+      if ($2 != 1)
+        error_message(7);
+      write_byte(0x38);
+      relative_jump($4);
+    }
+  | MNEMO_JR CONDITION ',' value_16bits {
+      if ($2 == 2)
+        write_byte(0x30);
+      else if ($2 == 1)
+        write_byte(0x28);
+      else if ($2 == 0)
+        write_byte(0x20);
+      else
+        error_message(9);
+      relative_jump($4);
+    }
+  | MNEMO_JP REGISTER_PAIR {
+      if ($2 != 2)
+        error_message(2);
+      write_byte(0xe9);
+    }
+  | MNEMO_JP REGISTER_IND_HL {
+      write_byte(0xe9);
+    }
+  | MNEMO_JP REGISTER_16_IX {
+      write_byte(0xdd);
+      write_byte(0xe9);
+    }
+  | MNEMO_JP REGISTER_16_IY {
+      write_byte(0xfd);
+      write_byte(0xe9);
+    }
+  | MNEMO_JP '[' REGISTER_16_IX ']' {
+      write_byte(0xdd);
+      write_byte(0xe9);
+    }
+  | MNEMO_JP '[' REGISTER_16_IY ']' {
+      write_byte(0xfd);
+      write_byte(0xe9);
+    }
+  | MNEMO_DJNZ value_16bits {
+      write_byte(0x10);
+      relative_jump($2);
+    }
 ;
 
 mnemo_call: MNEMO_CALL value_16bits {
-            write_byte(0xcd);
-            write_word($2);
-          }
-        | MNEMO_CALL CONDITION ',' value_16bits {
-            write_byte(0xc4 | ($2 << 3));
-            write_word($4);
-          }
-        | MNEMO_CALL REGISTER ',' value_16bits {
-            if ($2 != 1)
-              error_message(7);
-            write_byte(0xdc);
-            write_word($4);
-          }
-        | MNEMO_RET {
-            write_byte(0xc9);
-          }
-        | MNEMO_RET CONDITION {
-            write_byte(0xc0 | ($2 << 3));
-          }
-        | MNEMO_RET REGISTER {
-            if ($2 != 1)
-              error_message(7);
-            write_byte(0xd8);
-          }
-        | MNEMO_RETI {
-            write_byte(0xed);
-            write_byte(0x4d);
-          }
-        | MNEMO_RETN {
-            write_byte(0xed);
-            write_byte(0x45);
-          }
-        | MNEMO_RST value_8bits {
-            if (($2 % 8 != 0) || ($2 / 8 > 7) || ($2 / 8 < 0))
-              error_message(10);
-            write_byte(0xc7 | (($2 / 8) << 3));
-          }
+      write_byte(0xcd);
+      write_word($2);
+    }
+  | MNEMO_CALL CONDITION ',' value_16bits {
+      write_byte(0xc4 | ($2 << 3));
+      write_word($4);
+    }
+  | MNEMO_CALL REGISTER ',' value_16bits {
+      if ($2 != 1)
+        error_message(7);
+      write_byte(0xdc);
+      write_word($4);
+    }
+  | MNEMO_RET {
+      write_byte(0xc9);
+    }
+  | MNEMO_RET CONDITION {
+      write_byte(0xc0 | ($2 << 3));
+    }
+  | MNEMO_RET REGISTER {
+      if ($2 != 1)
+        error_message(7);
+      write_byte(0xd8);
+    }
+  | MNEMO_RETI {
+      write_byte(0xed);
+      write_byte(0x4d);
+    }
+  | MNEMO_RETN {
+      write_byte(0xed);
+      write_byte(0x45);
+    }
+  | MNEMO_RST value_8bits {
+      if (($2 % 8 != 0) || ($2 / 8 > 7) || ($2 / 8 < 0))
+        error_message(10);
+      write_byte(0xc7 | (($2 / 8) << 3));
+    }
 
 value: NUMBER {
-            $$ = $1;
-          }
-        | IDENTIFICATOR {
-            $$ = read_label($1);
-          }
-        | LOCAL_IDENTIFICATOR {
-            $$ = read_local($1);
-          }
-        | '-' value %prec NEGATIVE {
-            $$ = -$2;
-          }
-        | value OP_EQUAL value {
-            $$ = ($1 == $3);
-          }
-        | value OP_LESS_OR_EQUAL value {
-            $$ = ($1 <= $3);
-          }
-        | value OP_LESS value {
-            $$ = ($1 < $3);
-          }
-        | value OP_MORE_OR_EQUAL value {
-            $$ = ($1 >= $3);
-          }
-        | value OP_MORE value {
-            $$ = ($1 > $3);
-          }
-        | value OP_NOT_EQUAL value {
-            $$ = ($1 != $3);
-          }
-        | value OP_OR_LOG value {
-            $$ = ($1 || $3);
-          }
-        | value OP_AND_LOG value {$$ = ($1 && $3);
-          }
-        | value '+' value {
-            $$ = $1 + $3;
-          }
-        | value '-' value {
-            $$ = $1 - $3;
-          }
-        | value '*' value {
-            $$ = $1 * $3;
-          }
-        | value '/' value {
-            if (!$3)
-              error_message(1);
-            else
-              $$ = $1 / $3;
-          }
-        | value '%' value {
-            if (!$3)
-              error_message(1);
-            else
-              $$ = $1 % $3;
-          }
-        | '(' value ')' {
-            $$ = $2;
-          }
-        | '~' value %prec NEGATION {
-            $$ =~ $2;
-          }
-        | '!' value %prec OP_NEG_LOG {
-            $$ =! $2;
-          }
-        | value '&' value {
-            $$ = $1 & $3;
-          }
-        | value OP_OR value {
-            $$ = $1 | $3;
-          }
-        | value OP_XOR value {
-            $$ = $1 ^ $3;
-          }
-        | value SHIFT_L value {
-            $$ = $1 << $3;
-          }
-        | value SHIFT_R value {
-            $$ = $1 >> $3;
-          }
-        | PSEUDO_RANDOM '(' value ')' {
-          for (; ($$ = d_rand() & 0xff) >= $3;)
-            ;
-          }
-        | PSEUDO_INT '(' value_real ')' {
-            $$ = (int)$3;
-          }
-        | PSEUDO_FIX '(' value_real ')' {
-            $$ = (int)($3 * 256);
-          }
-        | PSEUDO_FIXMUL '(' value ',' value ')' {
-            $$ = (int)((((float)$3 / 256) * ((float) $5 / 256)) * 256);
-          }
-        | PSEUDO_FIXDIV '(' value ',' value ')' {
-            $$ = (int)((((float)$3 / 256) / ((float)$5 / 256)) * 256);
-          }
+      $$ = $1;
+    }
+  | IDENTIFICATOR {
+      $$ = read_label($1);
+    }
+  | LOCAL_IDENTIFICATOR {
+      $$ = read_local($1);
+    }
+  | '-' value %prec NEGATIVE {
+      $$ = -$2;
+    }
+  | value OP_EQUAL value {
+      $$ = ($1 == $3);
+    }
+  | value OP_LESS_OR_EQUAL value {
+      $$ = ($1 <= $3);
+    }
+  | value OP_LESS value {
+      $$ = ($1 < $3);
+    }
+  | value OP_MORE_OR_EQUAL value {
+      $$ = ($1 >= $3);
+    }
+  | value OP_MORE value {
+      $$ = ($1 > $3);
+    }
+  | value OP_NOT_EQUAL value {
+      $$ = ($1 != $3);
+    }
+  | value OP_OR_LOG value {
+      $$ = ($1 || $3);
+    }
+  | value OP_AND_LOG value {$$ = ($1 && $3);
+    }
+  | value '+' value {
+      $$ = $1 + $3;
+    }
+  | value '-' value {
+      $$ = $1 - $3;
+    }
+  | value '*' value {
+      $$ = $1 * $3;
+    }
+  | value '/' value {
+      if (!$3)
+        error_message(1);
+      else
+        $$ = $1 / $3;
+    }
+  | value '%' value {
+      if (!$3)
+        error_message(1);
+      else
+        $$ = $1 % $3;
+    }
+  | '(' value ')' {
+      $$ = $2;
+    }
+  | '~' value %prec NEGATION {
+      $$ =~ $2;
+    }
+  | '!' value %prec OP_NEG_LOG {
+      $$ =! $2;
+    }
+  | value '&' value {
+      $$ = $1 & $3;
+    }
+  | value OP_OR value {
+      $$ = $1 | $3;
+    }
+  | value OP_XOR value {
+      $$ = $1 ^ $3;
+    }
+  | value SHIFT_L value {
+      $$ = $1 << $3;
+    }
+  | value SHIFT_R value {
+      $$ = $1 >> $3;
+    }
+  | PSEUDO_RANDOM '(' value ')' {
+    for (; ($$ = d_rand() & 0xff) >= $3;)
+      ;
+    }
+  | PSEUDO_INT '(' value_real ')' {
+      $$ = (int)$3;
+    }
+  | PSEUDO_FIX '(' value_real ')' {
+      $$ = (int)($3 * 256);
+    }
+  | PSEUDO_FIXMUL '(' value ',' value ')' {
+      $$ = (int)((((float)$3 / 256) * ((float) $5 / 256)) * 256);
+    }
+  | PSEUDO_FIXDIV '(' value ',' value ')' {
+      $$ = (int)((((float)$3 / 256) / ((float)$5 / 256)) * 256);
+    }
 ;
 
 value_real: REAL {
-            $$ = $1;
-          }
-        | '-' value_real {
-            $$ = -$2;
-          }
-        | value_real '+' value_real {
-            $$ = $1 + $3;
-          }
-        | value_real '-' value_real {
-            $$ = $1 - $3;
-          }
-        | value_real '*' value_real {
-            $$ = $1 * $3;
-          }
-        | value_real '/' value_real {
-            if (!$3)
-              error_message(1);
-            else
-              $$ = $1 / $3;
-          }
-        | value '+' value_real {
-            $$ = (double)$1 + $3;
-          }
-        | value '-' value_real {
-            $$ = (double)$1 - $3;
-          }
-        | value '*' value_real {
-            $$ = (double)$1 * $3;
-          }
-        | value '/' value_real {
-            if ($3 < 1e-6)
-              error_message(1);
-            else
-              $$ = (double)$1 / $3;
-          }
-        | value_real '+' value {
-            $$ = $1 + (double)$3;
-          }
-        | value_real '-' value {
-            $$ = $1 - (double)$3;
-          }
-        | value_real '*' value {
-            $$ = $1 * (double)$3;
-          }
-        | value_real '/' value {
-            if (!$3)
-              error_message(1);
-            else
-              $$ = $1 / (double)$3;
-          }
-        | PSEUDO_SIN '(' value_real ')' {
-            $$ = sin($3);
-          }
-        | PSEUDO_COS '(' value_real ')' {
-            $$ = cos($3);
-          }
-        | PSEUDO_TAN '(' value_real ')' {
-            $$ = tan($3);
-          }
-        | PSEUDO_SQR '(' value_real ')' {
-            $$ = $3 * $3;
-          }
-        | PSEUDO_SQRT '(' value_real ')' {
-            $$ = sqrt($3);
-          }
-        | PSEUDO_PI {
-            $$ = 3.14159265358979323846;	/* use this instead of M_PI to avoid slightly different ROMs depending on compiler */
-          }
-        | PSEUDO_ABS '(' value_real ')' {
-            $$ = abs((int)$3);
-          }
-        | PSEUDO_ACOS '(' value_real ')' {
-            $$ = acos($3);
-          }
-        | PSEUDO_ASIN '(' value_real ')' {
-            $$ = asin($3);
-          }
-        | PSEUDO_ATAN '(' value_real ')' {
-            $$ = atan($3);
-          }
-        | PSEUDO_EXP '(' value_real ')' {
-            $$ = exp($3);
-          }
-        | PSEUDO_LOG '(' value_real ')' {
-            $$ = log10($3);
-          }
-        | PSEUDO_LN '(' value_real ')' {
-            $$ = log($3);
-          }
-        | PSEUDO_POW '(' value_real ',' value_real ')' {
-            $$ = pow($3, $5);
-          }
-        | '(' value_real ')' {
-            $$ = $2;
-          }
+      $$ = $1;
+    }
+  | '-' value_real {
+      $$ = -$2;
+    }
+  | value_real '+' value_real {
+      $$ = $1 + $3;
+    }
+  | value_real '-' value_real {
+      $$ = $1 - $3;
+    }
+  | value_real '*' value_real {
+      $$ = $1 * $3;
+    }
+  | value_real '/' value_real {
+      if (!$3)
+        error_message(1);
+      else
+        $$ = $1 / $3;
+    }
+  | value '+' value_real {
+      $$ = (double)$1 + $3;
+    }
+  | value '-' value_real {
+      $$ = (double)$1 - $3;
+    }
+  | value '*' value_real {
+      $$ = (double)$1 * $3;
+    }
+  | value '/' value_real {
+      if ($3 < 1e-6)
+        error_message(1);
+      else
+        $$ = (double)$1 / $3;
+    }
+  | value_real '+' value {
+      $$ = $1 + (double)$3;
+    }
+  | value_real '-' value {
+      $$ = $1 - (double)$3;
+    }
+  | value_real '*' value {
+      $$ = $1 * (double)$3;
+    }
+  | value_real '/' value {
+      if (!$3)
+        error_message(1);
+      else
+        $$ = $1 / (double)$3;
+    }
+  | PSEUDO_SIN '(' value_real ')' {
+      $$ = sin($3);
+    }
+  | PSEUDO_COS '(' value_real ')' {
+      $$ = cos($3);
+    }
+  | PSEUDO_TAN '(' value_real ')' {
+      $$ = tan($3);
+    }
+  | PSEUDO_SQR '(' value_real ')' {
+      $$ = $3 * $3;
+    }
+  | PSEUDO_SQRT '(' value_real ')' {
+      $$ = sqrt($3);
+    }
+  | PSEUDO_PI {
+      $$ = 3.14159265358979323846;	/* use this instead of M_PI to avoid slightly different ROMs depending on compiler */
+    }
+  | PSEUDO_ABS '(' value_real ')' {
+      $$ = abs((int)$3);
+    }
+  | PSEUDO_ACOS '(' value_real ')' {
+      $$ = acos($3);
+    }
+  | PSEUDO_ASIN '(' value_real ')' {
+      $$ = asin($3);
+    }
+  | PSEUDO_ATAN '(' value_real ')' {
+      $$ = atan($3);
+    }
+  | PSEUDO_EXP '(' value_real ')' {
+      $$ = exp($3);
+    }
+  | PSEUDO_LOG '(' value_real ')' {
+      $$ = log10($3);
+    }
+  | PSEUDO_LN '(' value_real ')' {
+      $$ = log($3);
+    }
+  | PSEUDO_POW '(' value_real ',' value_real ')' {
+      $$ = pow($3, $5);
+    }
+  | '(' value_real ')' {
+      $$ = $2;
+    }
 ;
 
 value_3bits: value {
-            if (($1 < 0) || ($1 > 7))
-              warning_message(3);
-            $$ = $1 & 0x07;
-          }
+      if (($1 < 0) || ($1 > 7))
+        warning_message(3);
+      $$ = $1 & 0x07;
+    }
 ;
 
 value_8bits: value {
-            if (($1 > 255) || ($1 < -128))
-              warning_message(2);
-            $$ = $1 & 0xff;
-          }
+      if (($1 > 255) || ($1 < -128))
+        warning_message(2);
+      $$ = $1 & 0xff;
+    }
 ;
 
 value_16bits: value {
-            if (($1 > 65535) || ($1 < -32768))
-              warning_message(1);
-            $$ = $1 & 0xffff;
-          }
+      if (($1 > 65535) || ($1 < -32768))
+        warning_message(1);
+      $$ = $1 & 0xffff;
+    }
 ;
 
 list_8bits: value_8bits {
-            write_byte($1);
-          }
-        | TEXT {
-            write_string($1);
-          }
-        | list_8bits ',' value_8bits {
-            write_byte($3);
-          }
-        | list_8bits ',' TEXT {
-            write_string($3);
-          }
+      write_byte($1);
+    }
+  | TEXT {
+      write_string($1);
+    }
+  | list_8bits ',' value_8bits {
+      write_byte($3);
+    }
+  | list_8bits ',' TEXT {
+      write_string($3);
+    }
 ;
 
 list_16bits: value_16bits {
-            write_word($1);
-          }
-        | TEXT {
-            write_string($1);
-          }
-        | list_16bits ',' value_16bits {
-            write_word($3);
-          }
-        | list_16bits ',' TEXT {
-            write_string($3);
-          }
+      write_word($1);
+    }
+  | TEXT {
+      write_string($1);
+    }
+  | list_16bits ',' value_16bits {
+      write_word($3);
+    }
+  | list_16bits ',' TEXT {
+      write_string($3);
+    }
 ;
 
 %%

--- a/src/dura.y
+++ b/src/dura.y
@@ -3944,90 +3944,91 @@ void create_subpage(int n, int address)
 
 void locate_32k()
 {
-  int i;
-  int locate32[31] = {
-	  0xCD, 0x38, 0x01, 0x0F,
-	  0x0F, 0xE6, 0x03, 0x4F,
-	  0x21, 0xC1, 0xFC, 0x85,
-	  0x6F, 0x7E, 0xE6, 0x80,
-	  0xB1, 0x4F, 0x2C, 0x2C,
-	  0x2C, 0x2C, 0x7E, 0xE6,
-	  0x0C, 0xB1, 0x26, 0x80,
-	  0xCD, 0x24, 0x00
+	int i;
+	int locate32[31] =
+	{
+		0xCD, 0x38, 0x01, 0x0F,
+		0x0F, 0xE6, 0x03, 0x4F,
+		0x21, 0xC1, 0xFC, 0x85,
+		0x6F, 0x7E, 0xE6, 0x80,
+		0xB1, 0x4F, 0x2C, 0x2C,
+		0x2C, 0x2C, 0x7E, 0xE6,
+		0x0C, 0xB1, 0x26, 0x80,
+		0xCD, 0x24, 0x00
 	};
-  for (i = 0; i < 31; i++)
-    write_byte(locate32[i]);
+
+	for (i = 0; i < 31; i++)
+		write_byte(locate32[i]);
 }
 
 int selector(int address)
 {
-  address = (address / pagesize) * pagesize;
+	address = (address / pagesize) * pagesize;
 
-  if ((mapper == KONAMI) && (address == 0x4000))
-    error_message(38);
+	if ((mapper == KONAMI) && (address == 0x4000))
+		error_message(38);
 
-  if (mapper == KONAMISCC)
-    address += 0x1000;
-  else if (mapper == ASCII8)
-    address = 0x6000 + (address - 0x4000) / 4;
-  else if (mapper == ASCII16)
-  {
-    if (address == 0x4000)
-      address = 0x6000;
-    else
-      address = 0x7000;
-  }
+	if (mapper == KONAMISCC)
+		address += 0x1000;
+	else if (mapper == ASCII8)
+		address = 0x6000 + (address - 0x4000) / 4;
+	else if (mapper == ASCII16)
+	{
+		if (address == 0x4000)
+			address = 0x6000;
+		else
+			address = 0x7000;
+	}
 
-  return address;
+	return address;
 }
 
 
 void select_page_direct(int n, int address)
 {
-  int sel;
+	int sel;
  
-  sel = selector(address);
+	sel = selector(address);
  
-  if ((pass == 2) && (!usedpage[n]))
-    error_message(39);
+	if ((pass == 2) && (!usedpage[n]))
+		error_message(39);
 
-  write_byte(0xf5);
-  write_byte(0x3e);
-  write_byte(n);
-  write_byte(0x32);
-  write_word(sel);
-  write_byte(0xf1);
+	write_byte(0xf5);
+	write_byte(0x3e);
+	write_byte(n);
+	write_byte(0x32);
+	write_word(sel);
+	write_byte(0xf1);
 }
 
 void select_page_register(int r, int address)
 {
-  int sel;
+	int sel;
 
-  sel = selector(address);
+	sel = selector(address);
 
-  if (r != 7)
-  {
-    write_byte(0xf5);					/* PUSH AF */
-    write_byte(0x40 | (7 << 3) | r);	/* LD A,r */
-  }
+	if (r != 7)
+	{
+		write_byte(0xf5);					/* PUSH AF */
+		write_byte(0x40 | (7 << 3) | r);	/* LD A,r */
+	}
 
-  write_byte(0x32);
-  write_word(sel);
+	write_byte(0x32);
+	write_word(sel);
 
-  if (r != 7)
-    write_byte(0xf1);					/* POP AF */
+	if (r != 7)
+		write_byte(0xf1);					/* POP AF */
 }
 
 
 int is_defined_symbol(char *name)
 {
-  int i;
+	int i;
 
-  for (i = 0; i < total_global; i++)
-    if (!strcmp(name, id_list[i].name))
-      return 1;
-
-  return 0;
+	for (i = 0; i < total_global; i++)
+		if (!strcmp(name, id_list[i].name))
+			return 1;
+	return 0;
 }
 
 
@@ -4039,8 +4040,8 @@ int is_defined_symbol(char *name)
 static unsigned long int rand_seed = 1;
 int d_rand()
 {
-  rand_seed = (rand_seed * 1103515245 + 12345);
-  return (unsigned int)(rand_seed / 65536) % (32767 + 1);
+	rand_seed = (rand_seed * 1103515245 + 12345);
+	return (unsigned int)(rand_seed / 65536) % (32767 + 1);
 }
 
 

--- a/src/dura.y
+++ b/src/dura.y
@@ -81,9 +81,9 @@
 		strtok allocated memory. This is never deleted, we must check this in the future to prevent memory leaks.
 	 v.0.18.4: [18/06/2017]
 		Unterminated string hotfix. Find a better way to solve it. Probably a more flex-like fix.
-     v.0.19: [15/03/2019]
-        Completed source code translation to English.
-        Replaced WAV writing code with new working version.
+	 v.0.19.0: [15/03/2019]
+		Completed source code translation to English.
+		Replaced WAV writing code with new working version.
 */
 
 /* C headers and definitions */
@@ -97,20 +97,8 @@
 
 #include "asmsx.h"
 
-#define VERSION "0.19"
+#define VERSION "0.19.0"
 #define DATE "15/03/2019"
-
-//#define Z80 0
-//#define ROM 1
-//#define BASIC 2
-//#define MSXDOS 3
-//#define MEGAROM 4
-//#define SINCLAIR 5
-
-//#define KONAMI 0
-//#define KONAMISCC 1
-//#define ASCII8 2
-//#define ASCII16 3
 
 #define MAX_ID 32000
 
@@ -3448,8 +3436,8 @@ int read_local(char *name)
 void create_txt()
 {
   /* Generate the name of output text file */
-  strcpy(fname_txt, fname_no_ext);
-  fname_txt = strcat(fname_txt, ".txt");
+  strncpy(fname_txt, fname_no_ext, PATH_MAX);
+  fname_txt = strncat(fname_txt, ".txt", PATH_MAX);
   fmsg = fopen(fname_txt, "wt");
   if (fmsg == NULL)
     return;
@@ -3828,7 +3816,7 @@ void initialize_memory()
 void initialize_system()
 {
   initialize_memory();
-  fname_msx = malloc(256);
+  fname_msx = malloc(PATH_MAX + 1);
   fname_msx[0] = 0;
   register_symbol("Eduardo_A_Robsy_Petrus_2007", 0, 0);
 }
@@ -4062,7 +4050,7 @@ int main(int argc, char *argv[])
   size_t t;
   int fileArg = 1;
   printf("-------------------------------------------------------------------------------\n");
-  printf(" asMSX v.%s. MSX cross-assembler. Eduardo A. Robsy Petrus [%s]\n",VERSION,DATE);
+  printf(" asMSX v.%s. MSX cross-assembler. Eduardo A. Robsy Petrus [%s]\n", VERSION, DATE);
   printf("-------------------------------------------------------------------------------\n");  
   if (argc > 3 || argc < 2)
   {
@@ -4080,13 +4068,13 @@ int main(int argc, char *argv[])
   
   clock();
   initialize_system();
-  fname_asm = malloc(256);
-  fname_src = malloc(256);
-  fname_p2 = malloc(256);
-  fname_bin = malloc(256);
-  fname_sym = malloc(256);
-  fname_txt = malloc(256);
-  fname_no_ext = malloc(256);
+  fname_asm = malloc(PATH_MAX + 1);
+  fname_src = malloc(PATH_MAX + 1);
+  fname_p2 = malloc(PATH_MAX + 1);
+  fname_bin = malloc(PATH_MAX + 1);
+  fname_sym = malloc(PATH_MAX + 1);
+  fname_txt = malloc(PATH_MAX + 1);
+  fname_no_ext = malloc(PATH_MAX + 1);
   if (!fname_no_ext)
   {
     fprintf(stderr, "Error: can't allocate memory for fname_no_ext\n");
@@ -4108,7 +4096,7 @@ int main(int argc, char *argv[])
 
   preprocessor1(fname_asm);
   preprocessor3(zilog);
-  sprintf(fname_p2, "~tmppre.%i", preprocessor2());
+  snprintf(fname_p2, PATH_MAX, "~tmppre.%i", preprocessor2());
   printf("Assembling source file %s\n", fname_asm);
 
   conditional[0] = 1;

--- a/src/lex.l
+++ b/src/lex.l
@@ -9,422 +9,422 @@ extern char *fname_p2;
 
 %%
 
-\43line         return PREPRO_LINE;
-\43file         return PREPRO_FILE;
+\43line		return PREPRO_LINE;
+\43file		return PREPRO_FILE;
 
 [ ]*
 
-'               return APOSTROPHE;
+'			return APOSTROPHE;
 
-"^"             return OP_XOR;
-"|"             return OP_OR;
+"^"			return OP_XOR;
+"|"			return OP_OR;
 
-"=="            return OP_EQUAL;
-"<="            return OP_LESS_OR_EQUAL;
-"<"             return OP_LESS;
-">="            return OP_MORE_OR_EQUAL;
-">"             return OP_MORE;
-"!="            return OP_NOT_EQUAL;
-"||"            return OP_OR_LOG;
-"&&"            return OP_AND_LOG;
-'!'             return OP_NEG_LOG;
+"=="		return OP_EQUAL;
+"<="		return OP_LESS_OR_EQUAL;
+"<"			return OP_LESS;
+">="		return OP_MORE_OR_EQUAL;
+">"			return OP_MORE;
+"!="		return OP_NOT_EQUAL;
+"||"		return OP_OR_LOG;
+"&&"		return OP_AND_LOG;
+'!'			return OP_NEG_LOG;
 
-'.'             {
-                  yylval.val = yytext[1];
-                  return NUMBER;
-                }
+'.'			{
+				yylval.val = yytext[1];
+				return NUMBER;
+			}
 
-[0-9]*"."[0-9]+ {
-                  yylval.real = atof(yytext);
-                  return REAL;
-                }
+[0-9]*"."[0-9]+	{
+					yylval.real = atof(yytext);
+					return REAL;
+				}
 
-[1-9][0-9]*     {
-                  yylval.val = atoi(yytext);
-                  return NUMBER;
-                }
+[1-9][0-9]*	{
+				yylval.val = atoi(yytext);
+				return NUMBER;
+			}
 
-#[0-9a-f]+      {
-                  yytext[0] = '0';
-                  yylval.val = strtol(yytext, NULL, 16);
-                  return NUMBER;
-                }
+#[0-9a-f]+	{
+				yytext[0] = '0';
+				yylval.val = strtol(yytext, NULL, 16);
+				return NUMBER;
+			}
 
-$[0-9a-f]+      {
-                  yytext[0] = '0';
-                  yylval.val = strtol(yytext, NULL, 16);
-                  return NUMBER;
-                }
+$[0-9a-f]+	{
+				yytext[0] = '0';
+				yylval.val = strtol(yytext, NULL, 16);
+				return NUMBER;
+			}
 
-0x[0-9a-f]+     {
-                  yylval.val = strtol(yytext, NULL, 16);
-                  return NUMBER;
-                }
+0x[0-9a-f]+	{
+				yylval.val = strtol(yytext, NULL, 16);
+				return NUMBER;
+			}
 
-[0-9][0-9a-f]*h {
-                  yylval.val = strtol(yytext, NULL, 16);
-                  return NUMBER;
-                }
+[0-9][0-9a-f]*h	{
+					yylval.val = strtol(yytext, NULL, 16);
+					return NUMBER;
+				}
 
-0[0-7]*         {
-                  yylval.val = strtol(yytext, NULL, 0);
-                  return NUMBER;
-                }
+0[0-7]*		{
+				yylval.val = strtol(yytext, NULL, 0);
+				return NUMBER;
+			}
 
-[0-7]+o         {
-                  yylval.val = strtol(yytext, NULL, 8);
-                  return NUMBER;
-                }
+[0-7]+o		{
+				yylval.val = strtol(yytext, NULL, 8);
+				return NUMBER;
+			}
 
-[0-1]+b         {
-                  yylval.val = strtol(yytext, NULL, 2);
-                  return NUMBER;
-                }
+[0-1]+b		{
+				yylval.val = strtol(yytext, NULL, 2);
+				return NUMBER;
+			}
 
-"$"             {
-                  yylval.val = ePC;
-                  return NUMBER;
-                }
+"$"			{
+				yylval.val = ePC;
+				return NUMBER;
+			}
 
-ld[ ]+sp        return MNEMO_LD_SP;
-ld              return MNEMO_LD;
-push            return MNEMO_PUSH;
-pop             return MNEMO_POP;
-ex              return MNEMO_EX;
-exx             return MNEMO_EXX;
-ldi             return MNEMO_LDI;
-ldir            return MNEMO_LDIR;
-ldd             return MNEMO_LDD;
-lddr            return MNEMO_LDDR;
-cpi             return MNEMO_CPI;
-cpir            return MNEMO_CPIR;
-cpd             return MNEMO_CPD;
-cpdr            return MNEMO_CPDR;
-add             return MNEMO_ADD;
-adc             return MNEMO_ADC;
-sub             return MNEMO_SUB;
-sbc             return MNEMO_SBC;
-and             return MNEMO_AND;
-or              return MNEMO_OR;
-xor             return MNEMO_XOR;
-cp              return MNEMO_CP;
-inc             return MNEMO_INC;
-dec             return MNEMO_DEC;
-daa             return MNEMO_DAA;
-cpl             return MNEMO_CPL;
-neg             return MNEMO_NEG;
-ccf             return MNEMO_CCF;
-scf             return MNEMO_SCF;
-nop             return MNEMO_NOP;
-halt            return MNEMO_HALT;
-di              return MNEMO_DI;
-ei              return MNEMO_EI;
-im              return MNEMO_IM;
-rlca            return MNEMO_RLCA;
-rla             return MNEMO_RLA;
-rrca            return MNEMO_RRCA;
-rra             return MNEMO_RRA;
-rlc             return MNEMO_RLC;
-rl              return MNEMO_RL;
-rrc             return MNEMO_RRC;
-rr              return MNEMO_RR;
-sla             return MNEMO_SLA;
-sll             return MNEMO_SLL;
-sra             return MNEMO_SRA;
-srl             return MNEMO_SRL;
-rld             return MNEMO_RLD;
-rrd             return MNEMO_RRD;
-bit             return MNEMO_BIT;
-set             return MNEMO_SET;
-res             return MNEMO_RES;
-in              return MNEMO_IN;
-ini             return MNEMO_INI;
-inir            return MNEMO_INIR;
-ind             return MNEMO_IND;
-indr            return MNEMO_INDR;
-out             return MNEMO_OUT;
-outi            return MNEMO_OUTI;
-otir            return MNEMO_OTIR;
-outd            return MNEMO_OUTD;
-otdr            return MNEMO_OTDR;
-jp              return MNEMO_JP;
-jr              return MNEMO_JR;
-djnz            return MNEMO_DJNZ;
-call            return MNEMO_CALL;
-ret             return MNEMO_RET;
-reti            return MNEMO_RETI;
-retn            return MNEMO_RETN;
-rst             return MNEMO_RST;
+ld[ ]+sp	return MNEMO_LD_SP;
+ld			return MNEMO_LD;
+push		return MNEMO_PUSH;
+pop			return MNEMO_POP;
+ex			return MNEMO_EX;
+exx			return MNEMO_EXX;
+ldi			return MNEMO_LDI;
+ldir		return MNEMO_LDIR;
+ldd			return MNEMO_LDD;
+lddr		return MNEMO_LDDR;
+cpi			return MNEMO_CPI;
+cpir		return MNEMO_CPIR;
+cpd			return MNEMO_CPD;
+cpdr		return MNEMO_CPDR;
+add			return MNEMO_ADD;
+adc			return MNEMO_ADC;
+sub			return MNEMO_SUB;
+sbc			return MNEMO_SBC;
+and			return MNEMO_AND;
+or			return MNEMO_OR;
+xor			return MNEMO_XOR;
+cp			return MNEMO_CP;
+inc			return MNEMO_INC;
+dec			return MNEMO_DEC;
+daa			return MNEMO_DAA;
+cpl			return MNEMO_CPL;
+neg			return MNEMO_NEG;
+ccf			return MNEMO_CCF;
+scf			return MNEMO_SCF;
+nop			return MNEMO_NOP;
+halt		return MNEMO_HALT;
+di			return MNEMO_DI;
+ei			return MNEMO_EI;
+im			return MNEMO_IM;
+rlca		return MNEMO_RLCA;
+rla			return MNEMO_RLA;
+rrca		return MNEMO_RRCA;
+rra			return MNEMO_RRA;
+rlc			return MNEMO_RLC;
+rl			return MNEMO_RL;
+rrc			return MNEMO_RRC;
+rr			return MNEMO_RR;
+sla			return MNEMO_SLA;
+sll			return MNEMO_SLL;
+sra			return MNEMO_SRA;
+srl			return MNEMO_SRL;
+rld			return MNEMO_RLD;
+rrd			return MNEMO_RRD;
+bit			return MNEMO_BIT;
+set			return MNEMO_SET;
+res			return MNEMO_RES;
+in			return MNEMO_IN;
+ini			return MNEMO_INI;
+inir		return MNEMO_INIR;
+ind			return MNEMO_IND;
+indr		return MNEMO_INDR;
+out			return MNEMO_OUT;
+outi		return MNEMO_OUTI;
+otir		return MNEMO_OTIR;
+outd		return MNEMO_OUTD;
+otdr		return MNEMO_OTDR;
+jp			return MNEMO_JP;
+jr			return MNEMO_JR;
+djnz		return MNEMO_DJNZ;
+call		return MNEMO_CALL;
+ret			return MNEMO_RET;
+reti		return MNEMO_RETI;
+retn		return MNEMO_RETN;
+rst			return MNEMO_RST;
 
-a               {
-                  yylval.val = 7;
-                  return REGISTER;
-                }
+a			{
+				yylval.val = 7;
+				return REGISTER;
+			}
 
-b               {
-                  yylval.val = 0;
-                  return REGISTER;
-                }
+b			{
+				yylval.val = 0;
+				return REGISTER;
+			}
 
-c               {
-                  yylval.val = 1;
-                  return REGISTER;
-                }
+c			{
+				yylval.val = 1;
+				return REGISTER;
+			}
 
-d               {
-                  yylval.val = 2;
-                  return REGISTER;
-                }
+d			{
+				yylval.val = 2;
+				return REGISTER;
+			}
 
-e               {
-                  yylval.val = 3;
-                  return REGISTER;
-                }
+e			{
+				yylval.val = 3;
+				return REGISTER;
+			}
 
-h               {
-                  yylval.val = 4;
-                  return REGISTER;
-                }
+h			{
+				yylval.val = 4;
+				return REGISTER;
+			}
 
-l               {
-                  yylval.val = 5;
-                  return REGISTER;
-                }
+l			{
+				yylval.val = 5;
+				return REGISTER;
+			}
 
-"["bc"]"        return REGISTER_IND_BC;
-"["de"]"        return REGISTER_IND_DE;
-"["hl"]"        return REGISTER_IND_HL;
-"["sp"]"        return REGISTER_IND_SP;
+"["bc"]"	return REGISTER_IND_BC;
+"["de"]"	return REGISTER_IND_DE;
+"["hl"]"	return REGISTER_IND_HL;
+"["sp"]"	return REGISTER_IND_SP;
 
-ixh             {
-                  yylval.val = 4;
-                  return REGISTER_IX;
-                }
+ixh			{
+				yylval.val = 4;
+				return REGISTER_IX;
+			}
 
-ixl             {
-                  yylval.val = 5;
-                  return REGISTER_IX;
-                }
+ixl			{
+				yylval.val = 5;
+				return REGISTER_IX;
+			}
 
-ix              return REGISTER_16_IX;
+ix			return REGISTER_16_IX;
 
-iyh             {
-                  yylval.val = 4;
-                  return REGISTER_IY;
-                }
+iyh			{
+				yylval.val = 4;
+				return REGISTER_IY;
+			}
 
-iyl             {
-                  yylval.val = 5;
-                  return REGISTER_IY;
-                }
+iyl			{
+				yylval.val = 5;
+				return REGISTER_IY;
+			}
 
-iy              return REGISTER_16_IY;
+iy			return REGISTER_16_IY;
 
-bc              {
-                  yylval.val = 0;
-                  return REGISTER_PAIR;
-                }
+bc			{
+				yylval.val = 0;
+				return REGISTER_PAIR;
+			}
 
-de              {
-                  yylval.val = 1;
-                  return REGISTER_PAIR;
-                }
+de			{
+				yylval.val = 1;
+				return REGISTER_PAIR;
+			}
 
-hl              {
-                  yylval.val = 2;
-                  return REGISTER_PAIR;
-                }
+hl			{
+				yylval.val = 2;
+				return REGISTER_PAIR;
+			}
 
-sp              {
-                  yylval.val = 3;
-                  return REGISTER_PAIR;
-                }
+sp			{
+				yylval.val = 3;
+				return REGISTER_PAIR;
+			}
 
-i               return REGISTER_I;
-r               return REGISTER_R;
-f               return REGISTER_F;
-af              return REGISTER_AF;
+i			return REGISTER_I;
+r			return REGISTER_R;
+f			return REGISTER_F;
+af			return REGISTER_AF;
 
-nz              {
-                  yylval.val=0;
-                  return CONDITION;
-                }
+nz			{
+				yylval.val=0;
+				return CONDITION;
+			}
 
-z               {
-                  yylval.val=1;
-                  return CONDITION;
-                }
+z			{
+				yylval.val=1;
+				return CONDITION;
+			}
 
-nc              {
-                  yylval.val = 2;
-                  return CONDITION;
-                }
+nc			{
+				yylval.val = 2;
+				return CONDITION;
+			}
 
-cc              {
-                  yylval.val = 3;
-                  return CONDITION;
-                }
+cc			{
+				yylval.val = 3;
+				return CONDITION;
+			}
 
-po              {
-                  yylval.val = 4;
-                  return CONDITION;
-                }
+po			{
+				yylval.val = 4;
+				return CONDITION;
+			}
 
-pe              {
-                  yylval.val = 5;
-                  return CONDITION;
-                }
+pe         {
+             yylval.val = 5;
+             return CONDITION;
+			}
 
-p               {
-                  yylval.val = 6;
-                  return CONDITION;
-                }
+p			{
+				yylval.val = 6;
+				return CONDITION;
+			}
 
-m               {
-                  yylval.val = 7;
-                  return CONDITION;
-                }
-                      
-0"/"1           return MULTI_MODE;
+m			{
+				yylval.val = 7;
+				return CONDITION;
+			}
+                 
+0"/"1		return MULTI_MODE;
 
-"."?db/[ \t]+     return PSEUDO_DB;
-"."?defb/[ \t]+   return PSEUDO_DB;
-"."?dt/[ \t]+     return PSEUDO_DB;
-"."?deft/[ \t]+   return PSEUDO_DB;
-"."?dw/[ \t]+     return PSEUDO_DW;
-"."?defw/[ \t]+   return PSEUDO_DW;
-"."?ds/[ \t]+     return PSEUDO_DS;
-"."?defs/[ \t]+   return PSEUDO_DS;
-"."?equ/[ \t]+    return PSEUDO_EQU;
-"="             return PSEUDO_ASSIGN;
-"."?page/[ \t\n]+         return PSEUDO_PAGE;
-"."?basic/[ \t\n]+        return PSEUDO_BASIC;
-"."?rom/[ \t\n]+          return PSEUDO_ROM;
-"."?megarom/[ \t\n]+      return PSEUDO_MEGAROM;
-"."?msxdos/[ \t\n]+       return PSEUDO_MSXDOS;
-"."?sinclair/[ \t\n]+	return PSEUDO_SINCLAIR;
-"."?bios/[ \t\n]+         return PSEUDO_BIOS;
-"."?org/[ \t\n]+          return PSEUDO_ORG;
-"."?start/[ \t\n]+        return PSEUDO_START;
-"."?byte/[ \t\n]+         return PSEUDO_BYTE;
-"."?word/[ \t\n]+         return PSEUDO_WORD;
-"."?incbin/[ \042\t\n]+   return PSEUDO_INCBIN;
-"."?skip/[ \t\n]+         return PSEUDO_SKIP;
-"."?debug/[ \t\n]+        return PSEUDO_DEBUG;
-"."?break/[ \t\n]+        return PSEUDO_BREAK;
-"."?breakpoint/[ \t\n]+   return PSEUDO_BREAK;
-"."?print/[ \t\n]+        return PSEUDO_PRINT;
-"."printdec/[ \t\n]+      return PSEUDO_PRINT;
-"."?printhex/[ \t\n]+     return PSEUDO_PRINTHEX;
-"."?printfix/[ \t\n]+     return PSEUDO_PRINTFIX;
-"."?printtext/[ \042\t\n]+        return PSEUDO_PRINTTEXT;
-.printstring/[ \042\t\n]+       return PSEUDO_PRINTTEXT;
-"."?size/[ \t\n]+         return PSEUDO_SIZE;
-"."?callbios/[ \t\n]+     return PSEUDO_CALLBIOS;
-"."?calldos/[ \t\n]+      return PSEUDO_CALLDOS;
-"."?phase/[ \t\n]+        return PSEUDO_PHASE;
-"."?dephase/[ \t\n]+      return PSEUDO_DEPHASE;
-"."?subpage/[ \t\n]+      return PSEUDO_SUBPAGE;
-"."?select/[ \t\n]+       return PSEUDO_SELECT;
-"."?search/[ \t\n]+       return PSEUDO_SEARCH;
-"."?zilog/[ \t\n]+        return PSEUDO_ZILOG;
-"."?filename/[ \042\t\n]+ return PSEUDO_FILENAME;
+"."?db/[ \t]+				return PSEUDO_DB;
+"."?defb/[ \t]+				return PSEUDO_DB;
+"."?dt/[ \t]+				return PSEUDO_DB;
+"."?deft/[ \t]+				return PSEUDO_DB;
+"."?dw/[ \t]+				return PSEUDO_DW;
+"."?defw/[ \t]+				return PSEUDO_DW;
+"."?ds/[ \t]+				return PSEUDO_DS;
+"."?defs/[ \t]+				return PSEUDO_DS;
+"."?equ/[ \t]+				return PSEUDO_EQU;
+"="							return PSEUDO_ASSIGN;
+"."?page/[ \t\n]+			return PSEUDO_PAGE;
+"."?basic/[ \t\n]+			return PSEUDO_BASIC;
+"."?rom/[ \t\n]+			return PSEUDO_ROM;
+"."?megarom/[ \t\n]+		return PSEUDO_MEGAROM;
+"."?msxdos/[ \t\n]+			return PSEUDO_MSXDOS;
+"."?sinclair/[ \t\n]+		return PSEUDO_SINCLAIR;
+"."?bios/[ \t\n]+			return PSEUDO_BIOS;
+"."?org/[ \t\n]+			return PSEUDO_ORG;
+"."?start/[ \t\n]+			return PSEUDO_START;
+"."?byte/[ \t\n]+			return PSEUDO_BYTE;
+"."?word/[ \t\n]+			return PSEUDO_WORD;
+"."?incbin/[ \042\t\n]+		return PSEUDO_INCBIN;
+"."?skip/[ \t\n]+			return PSEUDO_SKIP;
+"."?debug/[ \t\n]+			return PSEUDO_DEBUG;
+"."?break/[ \t\n]+			return PSEUDO_BREAK;
+"."?breakpoint/[ \t\n]+		return PSEUDO_BREAK;
+"."?print/[ \t\n]+			return PSEUDO_PRINT;
+"."printdec/[ \t\n]+		return PSEUDO_PRINT;
+"."?printhex/[ \t\n]+		return PSEUDO_PRINTHEX;
+"."?printfix/[ \t\n]+		return PSEUDO_PRINTFIX;
+"."?printtext/[ \042\t\n]+	return PSEUDO_PRINTTEXT;
+.printstring/[ \042\t\n]+	return PSEUDO_PRINTTEXT;
+"."?size/[ \t\n]+			return PSEUDO_SIZE;
+"."?callbios/[ \t\n]+		return PSEUDO_CALLBIOS;
+"."?calldos/[ \t\n]+		return PSEUDO_CALLDOS;
+"."?phase/[ \t\n]+			return PSEUDO_PHASE;
+"."?dephase/[ \t\n]+		return PSEUDO_DEPHASE;
+"."?subpage/[ \t\n]+		return PSEUDO_SUBPAGE;
+"."?select/[ \t\n]+			return PSEUDO_SELECT;
+"."?search/[ \t\n]+			return PSEUDO_SEARCH;
+"."?zilog/[ \t\n]+			return PSEUDO_ZILOG;
+"."?filename/[ \042\t\n]+	return PSEUDO_FILENAME;
 
-"."?if/[ \t\n]+           return  PSEUDO_IF;
-"."?ifdef/[ \t\n]+        return  PSEUDO_IFDEF;
-"."?else/[ \t\n]+         return  PSEUDO_ELSE;
-"."?endif/[ \t\n]+        return  PSEUDO_ENDIF;
+"."?if/[ \t\n]+				return  PSEUDO_IF;
+"."?ifdef/[ \t\n]+			return  PSEUDO_IFDEF;
+"."?else/[ \t\n]+			return  PSEUDO_ELSE;
+"."?endif/[ \t\n]+			return  PSEUDO_ENDIF;
 
-"."?cas/[ \042\t\n]+ {
-                  yylval.val = 1;
-                  return PSEUDO_CASSETTE;
-                }
+"."?cas/[ \042\t\n]+		{
+								yylval.val = 1;
+								return PSEUDO_CASSETTE;
+							}
 
-"."?cassette/[ \042\t\n]+ {
-                  yylval.val = 1;
-                  return PSEUDO_CASSETTE;
-                }
+"."?cassette/[ \042\t\n]+	{
+								yylval.val = 1;
+								return PSEUDO_CASSETTE;
+							}
 
-"."?wav/[ \042\t\n]+ {
-                  yylval.val = 2;
-                  return PSEUDO_CASSETTE;
-                }
+"."?wav/[ \042\t\n]+		{
+								yylval.val = 2;
+								return PSEUDO_CASSETTE;
+							}
 
-konami          {
-                  yylval.val = 0;
-                  return NUMBER;
-                }
+konami						{
+								yylval.val = 0;
+								return NUMBER;
+							}
 
-konamiscc       {
-                  yylval.val = 1;
-                  return NUMBER;
-                }
+konamiscc					{
+								yylval.val = 1;
+								return NUMBER;
+							}
 
-ascii8          {
-                  yylval.val = 2;
-                  return NUMBER;
-                }
+ascii8						{
+								yylval.val = 2;
+								return NUMBER;
+							}
 
-ascii16         {
-                  yylval.val = 3;
-                  return NUMBER;
-                }
+ascii16						{
+								yylval.val = 3;
+								return NUMBER;
+							}
 
-at/[ \t\n]+     return PSEUDO_AT;
-fixmul          return PSEUDO_FIXMUL;
-fixdiv          return PSEUDO_FIXDIV;
-int             return PSEUDO_INT;
-fix             return PSEUDO_FIX;
-sin             return PSEUDO_SIN;
-cos             return PSEUDO_COS;
-tan             return PSEUDO_TAN;
-sqrt            return PSEUDO_SQRT;
-sqr             return PSEUDO_SQR;
-pi              return PSEUDO_PI;
-abs             return PSEUDO_ABS;
-acos            return PSEUDO_ACOS;
-asin            return PSEUDO_ASIN;
-atan            return PSEUDO_ATAN;
-exp             return PSEUDO_EXP;
-log             return PSEUDO_LOG;
-ln              return PSEUDO_LN;
-pow             return PSEUDO_POW;
-random          return PSEUDO_RANDOM;
+at/[ \t\n]+	return PSEUDO_AT;
+fixmul		return PSEUDO_FIXMUL;
+fixdiv		return PSEUDO_FIXDIV;
+int			return PSEUDO_INT;
+fix			return PSEUDO_FIX;
+sin			return PSEUDO_SIN;
+cos			return PSEUDO_COS;
+tan			return PSEUDO_TAN;
+sqrt		return PSEUDO_SQRT;
+sqr			return PSEUDO_SQR;
+pi			return PSEUDO_PI;
+abs			return PSEUDO_ABS;
+acos		return PSEUDO_ACOS;
+asin		return PSEUDO_ASIN;
+atan		return PSEUDO_ATAN;
+exp			return PSEUDO_EXP;
+log			return PSEUDO_LOG;
+ln			return PSEUDO_LN;
+pow			return PSEUDO_POW;
+random		return PSEUDO_RANDOM;
 
-">>"            return SHIFT_R;
-"<<"            return SHIFT_L;
+">>"		return SHIFT_R;
+"<<"		return SHIFT_L;
 
-<<EOF>>		{
-                  unput('\n');
-                  pass++;
+<<EOF>>				{
+						unput('\n');
+						pass++;
 
-                  if (pass == 2)
-                    printf("Assembling labels, calls and jumps\n");
+						if (pass == 2)
+							printf("Assembling labels, calls and jumps\n");
 
-                  yyin = fopen(fname_p2, "r");
+						yyin = fopen(fname_p2, "r");
 
-                  return PSEUDO_END;
-		}
+						return PSEUDO_END;
+					}
 
-\42[^\42\n]+\42 {
-                  yylval.txt = strtok(yytext, "\42");
-                  yylval.txt = strtok(yytext, "\42");
-                  return TEXT;
-                }
+\42[^\42\n]+\42		{
+						yylval.txt = strtok(yytext, "\42");
+						yylval.txt = strtok(yytext, "\42");
+						return TEXT;
+					}
 
-[a-z_][a-z0-9_]* {
-                  yylval.txt = yytext;
-                  return IDENTIFICATOR;
-                }
+[a-z_][a-z0-9_]*	{
+						yylval.txt = yytext;
+						return IDENTIFICATOR;
+					}
 
 
-("@@"|".")[a-z0-9_]+  {
-				  /* v.0.18.2 Labels are checked the last, therfore we can use "." freely */
-                  yylval.txt = yytext;
-                  return LOCAL_IDENTIFICATOR;
-                }
+("@@"|".")[a-z0-9_]+	{
+							/* v.0.18.2 Labels are checked the last, therfore we can use "." freely */
+							yylval.txt = yytext;
+							return LOCAL_IDENTIFICATOR;
+						}
 
-[^\n^|]         return yytext[0];
-[\n]+           return EOL;
+[^\n^|]					return yytext[0];
+[\n]+					return EOL;
 
 %%

--- a/src/parser1.l
+++ b/src/parser1.l
@@ -12,7 +12,10 @@
 */
 
 %{
-#include <stdio.h>
+#pragma warning (disable : 4005)
+
+#include "asmsx.h"
+
 #define MAX_INCLUDE_LEVEL 16
 
 static char *p1_text, *p1_tmpstr, *p1_name;

--- a/src/parser1.l
+++ b/src/parser1.l
@@ -24,9 +24,9 @@ static FILE *p1_output_file, *p1_input_file;
 
 static struct
 {
-  YY_BUFFER_STATE buffer;
-  int line;
-  char *name;
+	YY_BUFFER_STATE buffer;
+	int line;
+	char *name;
 } p1_include_stack[MAX_INCLUDE_LEVEL];
 
 extern int prompt_error1(int);
@@ -43,130 +43,129 @@ extern int prompt_error1(int);
 
 <INITIAL>\42[^\42]*\42  strcat(p1_text, yytext);
 
-<INITIAL>"."?include/[ \042\t]+ {								  
-                  p1_tmpstr = NULL;
-                  BEGIN(inclusion);				
-                }
-                
-<inclusion>[ \t]*   /* strip spaces and tabs */
+<INITIAL>"."?include/[ \042\t]+	{
+									p1_tmpstr = NULL;
+									BEGIN(inclusion);
+								}
+
+<inclusion>[ \t]*		/* strip spaces and tabs */
 
 
-<inclusion>[^ \t\n]+    {		
-				    if (p1_tmpstr == NULL) { // 0.18.4 Hotfix Unterminated string (Spaces at the end of the the include)
-											 //	 - Bad fix. Fix with flex grammar properly
-						p1_tmpstr = strtok(yytext, "\42");					
-					}
-				}
+<inclusion>[^ \t\n]+	{
+							// 0.18.4 Hotfix Unterminated string (Spaces at the end of the the include)
+							// - Bad fix. Fix with flex grammar properly
+							if (p1_tmpstr == NULL)
+								p1_tmpstr = strtok(yytext, "\42");					
+						}
 
-<inclusion>[ \t]*\n   {				  
-                  int i;
+<inclusion>[ \t]*\n		{
+							int i;
 
-                  if (p1_tmpstr == NULL)
-                  {
-                    prompt_error1(5);
-                    exit(5);  /* code analyzer warning */
-                  }
+							if (p1_tmpstr == NULL)
+							{
+								prompt_error1(5);
+								exit(5);  /* code analyzer warning */
+							}
 
-                  if (p1_tmpstr[strlen(p1_tmpstr) - 1] <= 32)
-                  {
-                    prompt_error1(1);
-                    exit(1);  /* code analyzer warning */
-                  }
+							if (p1_tmpstr[strlen(p1_tmpstr) - 1] <= 32)
+							{
+								prompt_error1(1);
+								exit(1);  /* code analyzer warning */
+							}
 
-                  if (p1_include_index >= MAX_INCLUDE_LEVEL)
-                  {
-                    prompt_error1(2);
-                    exit(2);
-                  }
+							if (p1_include_index >= MAX_INCLUDE_LEVEL)
+							{
+								prompt_error1(2);
+								exit(2);
+							}
 				  
-                  for (i = 0; i < p1_include_index; i++)
-                    if (!strcmp(p1_tmpstr, p1_include_stack[i].name))
-                    {
-                      prompt_error1(4);
-                      exit(4);
-                    }
+							for (i = 0; i < p1_include_index; i++)
+								if (!strcmp(p1_tmpstr, p1_include_stack[i].name))
+								{
+									prompt_error1(4);
+									exit(4);
+								}
 
-                  p1_include_stack[p1_include_index].name = malloc(256);
-                  strcpy(p1_include_stack[p1_include_index].name, p1_name);
-                  p1_include_stack[p1_include_index].line = yylineno;
-                  p1_include_stack[p1_include_index++].buffer = YY_CURRENT_BUFFER;
+							p1_include_stack[p1_include_index].name = malloc(256);
+							strcpy(p1_include_stack[p1_include_index].name, p1_name);
+							p1_include_stack[p1_include_index].line = yylineno;
+							p1_include_stack[p1_include_index++].buffer = YY_CURRENT_BUFFER;
 
-				  
-                  yyin = fopen(p1_tmpstr, "r");
-                  if (!yyin)
-                  {
-                    prompt_error1(3);
-                    exit(3);
-                  }
+							yyin = fopen(p1_tmpstr, "r");
+							if (!yyin)
+							{
+								prompt_error1(3);
+								exit(3);
+							}
 
-                  printf("Including file %s\n", p1_tmpstr);
-                  yylineno = 1;                                    
-                  strcpy(p1_name, p1_tmpstr);                  
-                  fprintf(p1_output_file, "#file \042%s\042\n", p1_name);
-                  yy_switch_to_buffer(yy_create_buffer(yyin, YY_BUF_SIZE));
+							printf("Including file %s\n", p1_tmpstr);
+							yylineno = 1;                                    
+							strcpy(p1_name, p1_tmpstr);                  
+							fprintf(p1_output_file, "#file \042%s\042\n", p1_name);
+							yy_switch_to_buffer(yy_create_buffer(yyin, YY_BUF_SIZE));
 
-				  BEGIN(INITIAL);
-                }
+							BEGIN(INITIAL);
+						}
 
-<<EOF>>         {
-                  fclose(yyin);
-                  if (--p1_include_index >= 0)
-                  {
-                    yy_delete_buffer(YY_CURRENT_BUFFER);
-                    yy_switch_to_buffer(p1_include_stack[p1_include_index].buffer);
-                    yylineno = p1_include_stack[p1_include_index].line;
-                    strcpy(p1_name, p1_include_stack[p1_include_index].name);
-                    fprintf(p1_output_file, "#file \042%s\042\n", p1_name);
-                    free(p1_include_stack[p1_include_index].name);
-                  }
-                  else
-                  {
-                    if (strlen(p1_text) > 0)
-                      fprintf(p1_output_file, "#line %d\n%s\n", yylineno, p1_text);
-                    fprintf(p1_output_file, "%s", yytext);
-                    return 0;
-                  }
-                }
+<<EOF>>	{
+			fclose(yyin);
+			if (--p1_include_index >= 0)
+			{
+				yy_delete_buffer(YY_CURRENT_BUFFER);
+				yy_switch_to_buffer(p1_include_stack[p1_include_index].buffer);
+				yylineno = p1_include_stack[p1_include_index].line;
+				strcpy(p1_name, p1_include_stack[p1_include_index].name);
+				fprintf(p1_output_file, "#file \042%s\042\n", p1_name);
+				free(p1_include_stack[p1_include_index].name);
+			}
+			else
+			{
+				if (strlen(p1_text) > 0)
+					fprintf(p1_output_file, "#line %d\n%s\n", yylineno, p1_text);
+				fprintf(p1_output_file, "%s", yytext);
+				return 0;
+			}
+		}
 
-<INITIAL>";"[^\n]*      /* Skip assembler-style comments */
-<INITIAL>"//"[^\n]*     /* Skip C/C++ single line comments */
-<INITIAL>"--"[^\n]*     /* Skip ADA-style comments */
-<INITIAL>\15            /* Skip line feeds */
+<INITIAL>";"[^\n]*		/* Skip assembler-style comments */
+<INITIAL>"//"[^\n]*		/* Skip C/C++ single line comments */
+<INITIAL>"--"[^\n]*		/* Skip ADA-style comments */
+<INITIAL>\15			/* Skip line feeds */
 
-<INITIAL>"/*"   BEGIN(comment); /* Skip C/C++ multiple line comments */
-<comment>[^"*/"]*               /* Skip all within */
-<comment>"*/"   BEGIN(INITIAL);
+<INITIAL>"/*"			BEGIN(comment); /* Skip C/C++ multiple line comments */
+<comment>[^"*/"]*		/* Skip all within */
+<comment>"*/"			BEGIN(INITIAL);
 
-<INITIAL>"{"    BEGIN(pascal_comment);  /* Skip Pascal multiple line comments */
-<pascal_comment>[^}]*                   /* Skip all within */
-<pascal_comment>"}"     BEGIN(INITIAL);
+<INITIAL>"{"			BEGIN(pascal_comment);  /* Skip Pascal multiple line comments */
+<pascal_comment>[^}]*	/* Skip all within */
+<pascal_comment>"}"		BEGIN(INITIAL);
 
-<INITIAL>\42    {				  
-                  strcat(p1_text, yytext);
-                  BEGIN(chain);
-                }
+<INITIAL>\42			{
+							strcat(p1_text, yytext);
+							BEGIN(chain);
+						}
 
-<chain>\42      {
-                  strcat(p1_text, yytext);
-                  BEGIN(INITIAL);
-                }
+<chain>\42				{
+							strcat(p1_text, yytext);
+							BEGIN(INITIAL);
+						}
 
-<chain>\n       prompt_error1(1);
+<chain>\n				prompt_error1(1);
 
-<chain>[^\42\n] strcat(p1_text, yytext);
+<chain>[^\42\n]			strcat(p1_text, yytext);
 
-<INITIAL>[ \t]+ {
-                  if (strlen(p1_text) > 0)
-                    strcat(p1_text, " "); /* Should be 0 for Windows */
-                }
+<INITIAL>[ \t]+			{
+							if (strlen(p1_text) > 0)
+								strcat(p1_text, " "); /* Should be 0 for Windows */
+						}
 
-<INITIAL>\n     {
-                  if (strlen(p1_text) > 0)
-                    fprintf(p1_output_file, "#line %d\n%s\n", yylineno - 1, p1_text);  /* Should be 0 for Windows? */
-                  p1_text[0] = 0;
-                }
+<INITIAL>\n				{
+							if (strlen(p1_text) > 0)
+								fprintf(p1_output_file, "#line %d\n%s\n", yylineno - 1, p1_text);  /* Should be 0 for Windows? */
+							p1_text[0] = 0;
+						}
 
-<INITIAL>.      strcat(p1_text, yytext);
+<INITIAL>.				strcat(p1_text, yytext);
 
 %%
 
@@ -174,87 +173,85 @@ extern int prompt_error1(int);
 
 int prompt_error1(int c)
 {
-  fprintf(stderr, "%s, line %d: ", p1_name, yylineno - 1);
-  switch (c)
-  {
-    case 1:
-      fprintf(stderr, "Unterminated string\n");
-      break;
-    case 2:
-      fprintf(stderr, "Nested include level overflow\n");
-      break;
-    case 3:
-      fprintf(stderr, "Include file not found\n");
-      break;
-    case 4:
-      fprintf(stderr, "Recursive include\n");
-      break;
-    case 5:
-      fprintf(stderr, "Wrong file name\n");
-      break;
-    default:
-      fprintf(stderr, "Unknown error in prompt_error1()\n");
-  }
-  fclose(p1_output_file);
-  exit(c);
+	fprintf(stderr, "%s, line %d: ", p1_name, yylineno - 1);
+	switch (c)
+	{
+		case 1:
+			fprintf(stderr, "Unterminated string\n");
+			break;
+		case 2:
+			fprintf(stderr, "Nested include level overflow\n");
+			break;
+		case 3:
+			fprintf(stderr, "Include file not found\n");
+			break;
+		case 4:
+			fprintf(stderr, "Recursive include\n");
+			break;
+		case 5:
+			fprintf(stderr, "Wrong file name\n");
+			break;
+		default:
+			fprintf(stderr, "Unknown error in prompt_error1()\n");
+	}
+	fclose(p1_output_file);
+	exit(c);
 }
 
 int preprocessor1(char *input_name)
 {
-  /* Memory allocation for strings */
-  if (!(p1_text = malloc(256)))
-  {
-    fprintf(stderr, "Fatal: can't allocate memory for p1_text\n");
-	exit(1);
-  }
+	/* Memory allocation for strings */
+	if (!(p1_text = malloc(256)))
+	{
+		fprintf(stderr, "Fatal: can't allocate memory for p1_text\n");
+		exit(1);
+	}
 
-  if (!(p1_name = malloc(256)))
-  {
-    fprintf(stderr, "Fatal: can't allocate memory for p1_name\n");
-	exit(1);
-  }
+	if (!(p1_name = malloc(256)))
+	{
+		fprintf(stderr, "Fatal: can't allocate memory for p1_name\n");
+		exit(1);
+	}
   
-  /*
-  if (!(p1_tmpstr = malloc(256)))
-  {
-    fprintf(stderr, "Fatal: can't allocate memory for p1_tmpstr\n");
-	exit(1);
-  }*/ // Fix 0.18.3 - It doesn't use this as strtok already gives the reserved memory
-	  // ToDo: Check with valgrind.
-  
+	/*
+	if (!(p1_tmpstr = malloc(256)))
+	{
+		fprintf(stderr, "Fatal: can't allocate memory for p1_tmpstr\n");
+		exit(1);
+	}*/	// Fix 0.18.3 - It doesn't use this as strtok already gives the reserved memory
+		// ToDo: Check with valgrind.
 
-  /* Strings initialization */
-  p1_text[0] = 0;
+	/* Strings initialization */
+	p1_text[0] = 0;
 
-  /* Get source code name */
-  strcpy(p1_name, input_name);
+	/* Get source code name */
+	strcpy(p1_name, input_name);
 
-  /* Open original source file */
-  if ((p1_input_file = fopen(p1_name, "r")) == NULL)
-  {
-    fprintf(stderr, "Fatal: cannot open %s", input_name);
-    exit(1);
-  }
+	/* Open original source file */
+	if ((p1_input_file = fopen(p1_name, "r")) == NULL)
+	{
+		fprintf(stderr, "Fatal: cannot open %s", input_name);
+		exit(1);
+	}
 
-  /* Print parsing message */
-  printf("Parsing file %s\n", input_name);
+	/* Print parsing message */
+	printf("Parsing file %s\n", input_name);
 
-  /* Create p1_output_file file */
-  p1_output_file = fopen("~tmppre.0", "w");
-  fprintf(p1_output_file, "#file \042%s\042\n", p1_name);
- 
-  /* Start lexical scanner */
-  yyin = p1_input_file;
-  yylex();
- 
-  /* Close p1_output_file file */
-  fclose(p1_output_file);
+	/* Create p1_output_file file */
+	p1_output_file = fopen("~tmppre.0", "w");
+	fprintf(p1_output_file, "#file \042%s\042\n", p1_name);
 
-  /* Free string pointers */
-  free(p1_text);
-  free(p1_name);
-  //free(p1_tmpstr); // 0.18.3 - Not needed as malloc is not done.
-  
+	/* Start lexical scanner */
+	yyin = p1_input_file;
+	yylex();
 
-  return 0;
+	/* Close p1_output_file file */
+	fclose(p1_output_file);
+
+	/* Free string pointers */
+	free(p1_text);
+	free(p1_name);
+	//free(p1_tmpstr); // 0.18.3 - Not needed as malloc is not done.
+
+	return 0;
 }

--- a/src/parser2.l
+++ b/src/parser2.l
@@ -114,7 +114,7 @@ int preprocessor2()
 	char *filename;
 	int loop = 0;
 
-	filename = malloc(PATH_MAX + 1);
+	filename = malloc(PATH_MAX);
 	p2_text = malloc(0x1000);
 	p2_buffer = malloc(0x4000);
 	p2_text[0] = 0;
@@ -123,7 +123,7 @@ int preprocessor2()
 
 	do
 	{
-		snprintf(filename, PATH_MAX, "~tmppre.%i", loop + 1);
+		snprintf(filename, PATH_MAX - 1, "~tmppre.%i", loop + 1);
 
 		if ((input = fopen(filename, "r")) == NULL)
 		{
@@ -135,7 +135,7 @@ int preprocessor2()
  
 		loop++;
 
-		snprintf(filename, PATH_MAX, "~tmppre.%i", loop + 1);
+		snprintf(filename, PATH_MAX - 1, "~tmppre.%i", loop + 1);
 
 		p2_output = fopen(filename, "w");
 		p2_level = 0;

--- a/src/parser2.l
+++ b/src/parser2.l
@@ -29,128 +29,129 @@ extern void error_message(int);
 
 %%
 
-<INITIAL>"#"line[ \t]*[0-9]+\n {
-                  strcat(p2_text, yytext);
-                  p2_lines = atoi(&yytext[5]);
-                  BEGIN(line);
-                }
+<INITIAL>"#"line[ \t]*[0-9]+\n	{
+									strcat(p2_text, yytext);
+									p2_lines = atoi(&yytext[5]);
+									BEGIN(line);
+								}
 
-<line>.?rept[ \t]+      BEGIN(repnum);
+<line>.?rept[ \t]+				BEGIN(repnum);
 
-<line>.         {
-                  strcat(p2_text, yytext);
-                  BEGIN(INITIAL);
-                }
+<line>.							{
+									strcat(p2_text, yytext);
+									BEGIN(INITIAL);
+								}
 
-<repnum>[0-9]+[ \t]* {
-                  p2_number = atoi(yytext);
-                  p2_buffer[0] = 0;
-                  p2_text[0] = 0;
-                  BEGIN(rept);
-                }
+<repnum>[0-9]+[ \t]*			{
+									p2_number = atoi(yytext);
+									p2_buffer[0] = 0;
+									p2_text[0] = 0;
+									BEGIN(rept);
+								}
 
-<rept>.?rept[ \t]+[0-9]+[ \t]* {
-                  p2_buffer = strcat(p2_buffer, yytext);
-                  p2_nested++;
-                  p2_level++;
-                }
+<rept>.?rept[ \t]+[0-9]+[ \t]*	{
+									p2_buffer = strcat(p2_buffer, yytext);
+									p2_nested++;
+									p2_level++;
+								}
 
-<rept>"#"line[ \t]*[0-9]+\n[ \t]*.?endr[ \t]*\n {
-                  if (p2_nested)
-                  {
-                    p2_nested--;
-                    p2_buffer = strcat(p2_buffer, yytext);
-                  }
-                  else
-                  {
-                    int i;
+<rept>"#"line[ \t]*[0-9]+\n[ \t]*.?endr[ \t]*\n	{
+													if (p2_nested)
+													{
+														p2_nested--;
+														p2_buffer = strcat(p2_buffer, yytext);
+													}
+													else
+													{
+														int i;
 
-                    for (i = 0; i < p2_number; i++)
-                      fprintf(p2_output, "%s", p2_buffer);
+														for (i = 0; i < p2_number; i++)
+															fprintf(p2_output, "%s", p2_buffer);
 
-                    p2_buffer[0] = 0;
-                    BEGIN(INITIAL);
-                  }
-                }
+														p2_buffer[0] = 0;
+														BEGIN(INITIAL);
+													}
+												}
 
-<rept>.	        p2_buffer = strcat(p2_text, yytext);
+<rept>.							p2_buffer = strcat(p2_text, yytext);
 
-<rept>\n        p2_buffer = strcat(p2_buffer, yytext);
+<rept>\n						p2_buffer = strcat(p2_buffer, yytext);
 
-<rept><<EOF>>   error_message(2);
+<rept><<EOF>>					error_message(2);
 
-<repnum>.       prompt_error2(1);
+<repnum>.						prompt_error2(1);
 
-<INITIAL>\n     {
-                  fprintf(p2_output, "%s%s", p2_text, yytext);
-                  p2_text[0] = 0;
-                }
+<INITIAL>\n						{
+									fprintf(p2_output, "%s%s", p2_text, yytext);
+									p2_text[0] = 0;
+								}
 
-<INITIAL>.      strcat(p2_text, yytext);
+<INITIAL>.						strcat(p2_text, yytext);
 
 %%
 
 int prompt_error2(int c)
 {
-  fprintf(stderr, ", line %d: ", p2_lines);
-  switch (c)
-  {
-    case 1:
-      fprintf(stderr, "number expected in REPT\n");
-      break;
-    case 2:
-      fprintf(stderr, "REPT without ENDR\n");
-      break;
-    default:
-      fprintf(stderr, "Unknown error in prompt_error2()\n");
-  }
-  fclose(p2_output);
-  exit(c);
+	fprintf(stderr, ", line %d: ", p2_lines);
+	switch (c)
+	{
+		case 1:
+			fprintf(stderr, "number expected in REPT\n");
+			break;
+		case 2:
+			fprintf(stderr, "REPT without ENDR\n");
+			break;
+		default:
+			fprintf(stderr, "Unknown error in prompt_error2()\n");
+	}
+	fclose(p2_output);
+	exit(c);
 }
 
 int preprocessor2()
 {
-  FILE *input;
-  char *filename;
-  int loop = 0;
+	FILE *input;
+	char *filename;
+	int loop = 0;
 
-  filename = malloc(PATH_MAX + 1);
-  p2_text = malloc(0x1000);
-  p2_buffer = malloc(0x4000);
-  p2_text[0] = 0;
+	filename = malloc(PATH_MAX + 1);
+	p2_text = malloc(0x1000);
+	p2_buffer = malloc(0x4000);
+	p2_text[0] = 0;
 
-  printf("Expanding system macros\n");
+	printf("Expanding system macros\n");
 
-  do
-  {
-    snprintf(filename, PATH_MAX, "~tmppre.%i", loop + 1);
+	do
+	{
+		snprintf(filename, PATH_MAX, "~tmppre.%i", loop + 1);
 
-    if ((input = fopen(filename, "r")) == NULL)
-    {
-      fprintf(stderr, "Fatal: cannot process file %s\n", filename);
-      exit(1);
-    }
+		if ((input = fopen(filename, "r")) == NULL)
+		{
+			fprintf(stderr, "Fatal: cannot process file %s\n", filename);
+			exit(1);
+		}
 
-    yyin = input;
+		yyin = input;
  
-    loop++;
+		loop++;
 
-    snprintf(filename, PATH_MAX, "~tmppre.%i", loop + 1);
+		snprintf(filename, PATH_MAX, "~tmppre.%i", loop + 1);
 
-    p2_output = fopen(filename, "w");
-    p2_level = 0;
-    p2_nested = 0;
+		p2_output = fopen(filename, "w");
+		p2_level = 0;
+		p2_nested = 0;
 
-    yylex();
+		yylex();
 
-    fclose(input);
-    fclose(p2_output);
-  } while (p2_level);
+		fclose(input);
+		fclose(p2_output);
+	}
+	while (p2_level);
 
 /*
-  free(filename);
-  free(p2_text);
-  free(p2_buffer);
+	free(filename);
+	free(p2_text);
+	free(p2_buffer);
 */
-  return loop + 1;
+	return loop + 1;
 }

--- a/src/parser2.l
+++ b/src/parser2.l
@@ -8,7 +8,9 @@
 */
 
 %{
-#include<stdio.h>
+#include <stdio.h>
+
+#include "asmsx.h"
 
 static FILE *p2_output;
 static char *p2_text, *p2_buffer;
@@ -112,7 +114,7 @@ int preprocessor2()
   char *filename;
   int loop = 0;
 
-  filename = malloc(256);
+  filename = malloc(PATH_MAX + 1);
   p2_text = malloc(0x1000);
   p2_buffer = malloc(0x4000);
   p2_text[0] = 0;
@@ -121,7 +123,7 @@ int preprocessor2()
 
   do
   {
-    sprintf(filename, "~tmppre.%i", loop + 1);
+    snprintf(filename, PATH_MAX, "~tmppre.%i", loop + 1);
 
     if ((input = fopen(filename, "r")) == NULL)
     {
@@ -133,7 +135,7 @@ int preprocessor2()
  
     loop++;
 
-    sprintf(filename, "~tmppre.%i", loop+1);
+    snprintf(filename, PATH_MAX, "~tmppre.%i", loop + 1);
 
     p2_output = fopen(filename, "w");
     p2_level = 0;

--- a/src/parser2.l
+++ b/src/parser2.l
@@ -8,7 +8,7 @@
 */
 
 %{
-#include <stdio.h>
+#pragma warning (disable : 4005)
 
 #include "asmsx.h"
 

--- a/src/parser3.l
+++ b/src/parser3.l
@@ -23,74 +23,71 @@ static char *p3_text;
 
 %%          
 
-<INITIAL>"#"line[ \t]*[0-9]+\n {
-                  strcat(p3_text, yytext);
-                  BEGIN(line);
-                }
+<INITIAL>"#"line[ \t]*[0-9]+\n	{
+									strcat(p3_text, yytext);
+									BEGIN(line);
+								}
 
-<INITIAL>\n     {
-                  fprintf(p3_output, "%s%s", p3_text, yytext);
-                  p3_text[0] = 0;
-                }
+<INITIAL>\n						{
+									fprintf(p3_output, "%s%s", p3_text, yytext);
+									p3_text[0] = 0;
+								}
 
-<INITIAL>.      strcat(p3_text, yytext);
+<INITIAL>.						strcat(p3_text, yytext);
 
-<line>.?zilog[ \t]*\n {
-                  strcat(p3_text, yytext);
-                  printf("Using standard Zilog syntax\n");
-                  BEGIN(zilog); //Done in main
-                }
+<line>.?zilog[ \t]*\n			{
+									strcat(p3_text, yytext);
+									printf("Using standard Zilog syntax\n");
+									BEGIN(zilog); //Done in main
+								}
 
-<line>.         {
-                  strcat(p3_text, yytext);
-                  BEGIN(INITIAL);                     
-                }
+<line>.							{
+									strcat(p3_text, yytext);
+									BEGIN(INITIAL);
+								}
 
-<zilog>\42[^\42\n]+\42  strcat(p3_text, yytext);
+<zilog>\42[^\42\n]+\42			strcat(p3_text, yytext);
 
-<zilog>"("      strcat(p3_text, "[");
-<zilog>")"      strcat(p3_text, "]");
-<zilog>"["      strcat(p3_text, "(");
-<zilog>"]"      strcat(p3_text, ")");
-<zilog>.        strcat(p3_text, yytext);
-<zilog>\n       {
-                  fprintf(p3_output, "%s%s", p3_text, yytext);
-                  p3_text[0] = 0;
-                }
+<zilog>"("						strcat(p3_text, "[");
+<zilog>")"						strcat(p3_text, "]");
+<zilog>"["						strcat(p3_text, "(");
+<zilog>"]"						strcat(p3_text, ")");
+<zilog>.						strcat(p3_text, yytext);
+<zilog>\n						{
+									fprintf(p3_output, "%s%s", p3_text, yytext);
+									p3_text[0] = 0;
+								}
 
 %%
 
 int preprocessor3(int zilogVal)
 {
-  const char* tmp0 = "~tmppre.0";
-  FILE *input;
+	const char* tmp0 = "~tmppre.0";
+	FILE *input;
 
-  p3_text = malloc(0x1000);
-  p3_text[0] = 0;
+	p3_text = malloc(0x1000);
+	p3_text[0] = 0;
 
-  if ((input = fopen(tmp0, "r")) == NULL)
-  {
-    fprintf(stderr, "Fatal: cannot process file %s", tmp0);
-    exit(1);
-  }
+	if ((input = fopen(tmp0, "r")) == NULL)
+	{
+		fprintf(stderr, "Fatal: cannot process file %s", tmp0);
+		exit(1);
+	}
 
-  yyin = input;
- 
-  p3_output = fopen("~tmppre.1","w");
+	yyin = input;
+	p3_output = fopen("~tmppre.1","w");
 
-	
+	if(zilogVal) {
+		printf("Using standard Zilog syntax\n");
+		BEGIN(zilog);
+	}
 
-  if(zilogVal) {
-	printf("Using standard Zilog syntax\n");
-	BEGIN(zilog);
-  }   
+	yylex();
 
-  yylex();
+	fclose(input);
+	fclose(p3_output);
 
-  fclose(input);
-  fclose(p3_output);
+	free(p3_text);
 
-  free(p3_text);
-
-  return 0;
+	return 0;
 }

--- a/src/parser3.l
+++ b/src/parser3.l
@@ -5,11 +5,12 @@
 	Functions:
 		1.-Identify ZILOG macro
 		2.-Set accordingly indirection and mathematical style 
-		
 */
 
 %{
-#include <stdio.h>
+#pragma warning (disable : 4005)
+
+#include "asmsx.h"
 
 static FILE *p3_output;
 static char *p3_text;


### PR DESCRIPTION
In addition to coding style document and source formatting, following was done:

- replace 256 magic number for file name strings to PATH_MAX;
- switch some strcpy() to strncpy() using PATH_MAX for file names;
- move all standard library header files to asmsx.h, plan9 style. This is supposed to speed up compilation a bit.