### PR TITLE
Add git commit hash when compile with Makefile

### DIFF
--- a/src/dura.y
+++ b/src/dura.y
@@ -11,8 +11,12 @@
 
 #include "asmsx.h"
 
-#define VERSION "1.0 beta"
-#define DATE "01/12/2020"
+#ifndef VERSION
+#define VERSION "1.0.0-beta"
+#endif
+#ifndef DATE
+#define DATE "2020-12-01"
+#endif
 
 #define MAX_ID 32000
 

--- a/src/makefile
+++ b/src/makefile
@@ -1,11 +1,16 @@
 all:	asmsx
 
+VERSION_STATIC = 1.0.0-beta
+DATE_STATIC = 2020-12-01
+
+VERSION := $(if $(shell git status 2>/dev/null),$(shell git describe --tags --always 2>/dev/null),$(VERSION_STATIC))
+DATE := $(if $(shell git status 2>/dev/null),$(shell git show -s --format=%as HEAD 2>/dev/null),$(DATE_STATIC))
+
 CC=gcc
 CCOSX=o64-clang
 c_files=dura.tab.c lex.yy.c lex.parser1.c lex.parser2.c lex.parser3.c asmsx.c\
 		labels.c
-OPT=-lm -O2 -Os -s -Wall -Wextra
-VERSION=1.0.beta
+OPT=-lm -O2 -Os -s -Wall -Wextra -DVERSION=\"$(VERSION)\" -DDATE=\"$(DATE)\"
 
 HEADERS= asmsx.h labels.h
 

--- a/src/parser1.l
+++ b/src/parser1.l
@@ -174,7 +174,9 @@ extern int prompt_error1(int);
 
 %%
 
+#ifndef VERSION
 #define VERSION 
+#endif
 
 int prompt_error1(int c)
 {


### PR DESCRIPTION
Fixes #37 , but note that this may not work with MSBuild.

Also using version naming from Semantic Version. (major.minor.patch-beta)