### PR TITLE
Add gitattributes and edit Github Actions workflow run

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+
+*.c text
+*.h text
+*.sln text eol=crlf
+
+# ignore folder for stats
+code/* linguist-vendored

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,16 @@ name: Build
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - 'doc/**'
+      - 'ref/**'
+      - '*.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - 'doc/**'
+      - 'ref/**'
+      - '*.md'
 
 jobs:
   windows:


### PR DESCRIPTION
.gitattributes will set how files are saved, refering to CRLF or LF. This has a normal config to let git use the best way to choose.
Also will update Github statistics to ignore the "Assembler" amount of code.

On the other hand, if modifying any docs or README files, the Build workflow won't execute.