### PR TITLE
Build and upload binaries on Release publish

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,4 @@
-name-template: "asMSX v.$NEXT_PATCH_VERSION"
+name-template: "asMSX v$NEXT_PATCH_VERSION"
 tag-template: "$NEXT_PATCH_VERSION"
 version-template: "$MAJOR.$MINOR.$PATCH"
 change-template: "* #$NUMBER - $TITLE , thanks to @$AUTHOR!"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,5 +120,5 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
-        files: 'assets/*'
+        files: 'assets/asmsx-**'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ on:
     types: [released]
   push:
     branches: [ master ]
-    tags:
-      - "*.*.*"
     paths-ignore:
       - 'doc/**'
       - 'ref/**'
@@ -108,7 +106,7 @@ jobs:
         path: asmsx
 
   release:
-    name: Release
+    name: Upload to Release
     runs-on: ubuntu-latest
     needs: [windows, linux, linux-armhf, osx]
     if: startsWith(github.ref, 'refs/tags/')
@@ -117,6 +115,19 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         path: assets
+    - name: Rename artifacts
+      working-directory: assets
+      run: |
+        for FOLDER in *; do
+          cd $FOLDER
+          chmod a+x *
+          if [[ "$FOLDER" == *"win"* ]]; then
+            mv * $(basename $PWD).exe
+          else
+            mv * $(basename $PWD)
+          fi
+          cd ..
+        done
     - name: Release
       uses: softprops/action-gh-release@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,9 +111,6 @@ jobs:
     needs: [windows, linux, linux-armhf, osx]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     - name: Download artifacts
       uses: actions/download-artifact@v2
       with:
@@ -121,7 +118,5 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
-        generate_release_notes: false
-        files: |
-          assets/*
+        files: 'assets/*'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,5 +120,5 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
-        files: 'assets/asmsx-**'
+        files: 'assets/asmsx-*/*'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build
 on:
   push:
     branches: [ master ]
+    tags:
+      - "*.*.*"
     paths-ignore:
       - 'doc/**'
       - 'ref/**'
@@ -102,4 +104,24 @@ jobs:
       with:
         name: asmsx-osx
         path: asmsx
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [windows, linux, linux-armhf, osx]
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Download artifacts
+      uses: actions/download-artifact@v2
+      with:
+        path: assets
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        generate_release_notes: false
+        files: |
+          assets/*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build
 
 on:
+  release:
+    types: [released]
   push:
     branches: [ master ]
     tags:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
When a GitHub **Release** is **published**, the same **build** Workflow will rebuild the binaries and upload them.
No need to run **git tag**, just use the fancy GitHub web UI :) 