### PR TITLE
Remove periods in version display

### DIFF
--- a/src/dura.y
+++ b/src/dura.y
@@ -4537,7 +4537,7 @@ int main(int argc, char *argv[]) {
   #endif
 
   printf("-------------------------------------------------------------------------------\n");
-  printf(" asMSX v.%s. MSX cross-assembler. asMSX Team. [%s]\n", VERSION, DATE);
+  printf(" asMSX v%s MSX cross-assembler. asMSX Team. [%s]\n", VERSION, DATE);
   printf("-------------------------------------------------------------------------------\n\n");
 
   // External vars init


### PR DESCRIPTION
Current display:
```
-------------------------------------------------------------------------------
 asMSX v.1.1.4. MSX cross-assembler. asMSX Team. [2021-12-09]
-------------------------------------------------------------------------------
```

This is a minor change, to properly display the version. Should be `asMSX v1.1.4 MSX cross-assembler.`