### PR TITLE
Register variable ASMSX for cross-assemblers

### DIFF
--- a/src/dura.y
+++ b/src/dura.y
@@ -3770,9 +3770,10 @@ void register_label(char *name)
     }
 
     // Find if the label is already registered
-    i = search_label(id_list, name, 0, total_global);
-    if (i != -1) error_message(14, fname_src, lines); // If label found - Error, redefine, fname_src, linesd!
-
+    if (is_defined_symbol(name)) {
+      // If label found - Error, redefine, fname_src, linesd!
+      error_message(14, fname_src, lines);
+    }
 
 	if (++total_global == MAX_ID)
 		error_message(11, fname_src, lines);
@@ -3814,7 +3815,6 @@ void register_local(char *name)
 
 void register_symbol(char *name, int n, int _rom_type)
 {
-	int i;
 	char *_name;
 
 	if (pass == 2)
@@ -3825,9 +3825,9 @@ void register_symbol(char *name, int n, int _rom_type)
     }
 
     // Search if the symbol is defined. Error if found
-    i = search_label(id_list, name, 0, total_global);
-	if (i != -1) error_message(14, fname_src, lines);
-
+    if (is_defined_symbol(name)) {
+      error_message(14, fname_src, lines);
+    }
 
     // If maximum number of label names is exceeded, crash!
 	if (++total_global == MAX_ID)
@@ -4597,6 +4597,7 @@ int main(int argc, char *argv[]) {
   fname_msx = malloc(PATH_MAX);
   fname_msx[0] = 0;
   register_symbol("Eduardo_A_Robsy_Petrus_2007", 0, 0);
+  register_symbol("ASMSX", 0, 0);
 
   fname_asm = malloc(PATH_MAX);    assert(fname_asm != NULL);
   fname_src = malloc(PATH_MAX);    assert(fname_src != NULL);

--- a/test/features/program.feature
+++ b/test/features/program.feature
@@ -43,3 +43,17 @@ Feature: Test program functions
     | name     | expect   |
     | test2    | "test2 " |
     | test1234 | "test12" |
+
+  Scenario: Test asMSX defined code
+    Given I write the code to test.asm
+      """
+      IFDEF ASMSX
+        PRINTTEXT "Hello ASMSX!"
+      ELSE
+        PRINTTEXT "Hello unknown assembler!"
+      ENDIF
+      .db "HELLO"
+      """
+    When I build test.asm
+    Then text file contains Hello ASMSX
+    And text file does not contain unknown assembler


### PR DESCRIPTION
This allows to use IFDEF ASMSX in order to perform specific actions in asMSX.

Relates to #103