### PR TITLE
docker: Run with user id to preserve owner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,12 @@ COPY . /workdir/
 RUN useradd -u 1000 --no-create-home asmsx
 RUN make -C /workdir CFLAGS="-static" 
 
-FROM scratch
+FROM scratch AS staging
 COPY --from=build /workdir/asmsx /bin/asmsx
 COPY --from=build /etc/passwd /etc/passwd
+
+FROM scratch
+COPY --from=staging / /
 
 WORKDIR /src
 ENTRYPOINT ["/bin/asmsx"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,12 @@ RUN apt update && \
     libbison-dev libfl-dev build-essential \
     flex bison git libpthread-stubs0-dev
 COPY . /workdir/
+RUN useradd -u 1000 --no-create-home asmsx
 RUN make -C /workdir CFLAGS="-static" 
 
 FROM scratch
 COPY --from=build /workdir/asmsx /bin/asmsx
+COPY --from=build /etc/passwd /etc/passwd
 
 WORKDIR /src
 ENTRYPOINT ["/bin/asmsx"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Please read [asMSX manual](doc/asmsx.md) to learn more.
 Also you can use Docker image from GitHub Packages:
 
 ```sh
-docker pull ghcr.io/fubukimaru/asmsx:master
+docker pull ghcr.io/fubukimaru/asmsx
 ```
 
 If you'd like to contribute to this project, please take a look at our [coding style guide](doc/coding-style.md).

--- a/doc/asmsx.md
+++ b/doc/asmsx.md
@@ -141,7 +141,7 @@ More options are available, check the file for more information.
 You can run asMSX as a Docker container available from GitHub Packages:
 
 ```sh
-docker run -v $PWD:/src ghcr.io/fubukimaru/asmsx:master FILE.ASM
+docker run --rm -v $PWD:/src -w /src -u $(id -u):$(id -g) ghcr.io/fubukimaru/asmsx FILE.ASM
 ```
 
 Also you can integrate asMSX in GitHub Actions Workflow by using


### PR DESCRIPTION
Instead of running as default with `root` user, copy `/etc/passwd` to allow changing `uid`.