### PR TITLE
chores: Removed unneded test

### DIFF
--- a/test/features/bugs.feature
+++ b/test/features/bugs.feature
@@ -91,31 +91,6 @@ Feature: Fixing issues
     Then file outfile.com exists
     And file outfile.sym exists
 
-  @wip
-  Scenario: Issue #58 INCLUDE inside an IF is not ignored
-    Given I write the code to test.asm
-      """
-      USE_SCREEN = 2
-
-      IF USE_SCREEN == 2
-        .INCLUDE "screen2.com"
-      ENDIF
-
-      IF USE_SCREEN == 4
-        .INCLUDE "screen4.com"
-      ENDIF
-      """
-    And I write to screen2.com
-      """
-      .db "SCREEN2"
-      """
-    And I write to screen4.com
-      """
-      .db "SCREEN4"
-      """
-    When I build test.asm
-    Then build output should not contain Including file screen4.com
-
   Scenario: Issue #106 Include a file without newline breaks
     Given I write the code to test.asm
       """


### PR DESCRIPTION
Removed test that is not needed anymore as printing "we have included x file"  is the expected now to happen even if it is inside of an `IF`.