### PR TITLE
release fix: MacOS renaming artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
         for FOLDER in *; do
           cd $FOLDER
           chmod a+x *
-          if [[ "$FOLDER" == *"win"* ]]; then
+          if [[ "$FOLDER" == *"-win"* ]]; then
             mv * $(basename $PWD).exe
           else
             mv * $(basename $PWD)


### PR DESCRIPTION
`darwin` contains `win` and renames executable file to `.exe`.

Expected result is to target `-win-x86-64` and `-win-i686`.