### PR TITLE
fix: Exit 2 on wrong arguments instead of exit 0

### DIFF
--- a/src/dura.y
+++ b/src/dura.y
@@ -4598,7 +4598,7 @@ int main(int argc, char *argv[]) {
     printf("Syntax: asMSX [-z|-s|-vv|-r] [file.asm]\n");
   #endif
 
-    exit(0);
+    exit(2);
   }
 
   clock();


### PR DESCRIPTION
Instead of saying that everything is ok, if we misuse the program arguments it will throw an error 2.